### PR TITLE
[Docs] PR作成時のIssue番号自動埋め込み手順を追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,17 @@ Issue番号を常に意識してコードを書く。
 
 ### 4. PR作成
 
+**PowerShell環境での推奨方法（Issue番号自動埋め込み）:**
+
+```powershell
+# テンプレート内容を保持しつつ、Closes #XX を自動追記
+gh pr create --title "[Docs] 要約" `
+  --body "$(Get-Content .github/pull_request_template.md -Raw)`n`nCloses #XX" `
+  --label type:docs --label area:docs --label risk:low --label cost:none
+```
+
+**シンプルな方法（手動でIssue番号を指定）:**
+
 ```bash
 gh pr create --title "[Type] 要約" --body "Closes #XX" \
   --label "type:feature,area:infra,risk:low,cost:none"
@@ -99,6 +110,8 @@ gh pr create --title "[Type] 要約" --body "Closes #XX" \
 
 **必須事項:**
 - PR本文に `Closes #XX` を記載（Issueと自動連携）
+  - ⚠️ テンプレート使用時は `Closes #` のままになるので**必ずIssue番号を埋める**こと
+  - 推奨: PowerShell方式でテンプレート内容＋Issue番号を自動追記
 - Issueと同じラベルを付与
 - 変更内容の要約を記載
 - 影響範囲を明記


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的 *必須*
<!-- なぜこの変更が必要か（1-2行） -->

## 変更内容 *必須*
<!-- 具体的に何を変更したか（1行要点） -->
**変更タイプ**: Doc-only / Config / Network / Data / Capacity（いずれか選択）

## 影響範囲 *必須*
<!-- 対象/非対象の一言 -->
- **対象**: 
- **非対象**: 

## 影響チェック *必須*
- [ ] **ダウンタイム**: なし / 計画済み
- [ ] **コスト影響**: なし / 小 / 中 / 大
- [ ] **リスク**: Low / Medium / High

<details>
<summary>詳細（該当時のみ必須）</summary>

**ダウンタイム詳細**（計画ありの場合）:
**コスト根拠**（小/中/大の場合）:
**リスク根拠**（Medium/Highの場合）:

</details>

## 可観測性/検証 *条件付き*
<!-- Doc-onlyなら"No-op（適用外）"、それ以外は指標・期間・合格条件 -->

## ロールバック *条件付き*
<!-- Stateful/本番影響がある変更時は必須 -->

## 承認/リリース連携 *推奨*
- **必須承認者**: @xxx / なし
- **リリースノート**: 要 / 不要
- **推奨ラベル**: type:doc, area:github, risk:low, cost:none

<details>
<summary>テスト結果/検証手順</summary>

</details>

## メモ（レビューポイント）
<!-- レビュアーに見てほしい箇所 -->

Closes # *必須*

Closes #55