### PR TITLE
[CI/CD] セキュリティスキャン自動停止

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,11 +3,12 @@
 
 name: Security Scan
 on:
-  pull_request:
-    branches: [main, feature/develop]
-  schedule:
-    - cron: "0 0 * * 1"
   workflow_dispatch:
+    # 手動実行のみ許可（PRやスケジュールでは実行されない）
+  # pull_request:
+  #   branches: [main, feature/develop]
+  # schedule:
+  #   - cron: "0 0 * * 1"
 jobs:
   dependency-scan:
     name: Dependency Vulnerability Scan


### PR DESCRIPTION
Closes #80\n\n- .github/workflows/security-scan.yml の on: セクションを workflow_dispatch のみ有効化\n- pull_request/scheduleトリガーはYAMLコメントアウトで残す\n- 必要時にすぐ復元できるよう運用履歴を明記