### PR TITLE
ci: support lightweight issue templates

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -25,12 +25,12 @@ jobs:
             const hasAll = (headings) =>
               headings.every((heading) => body.includes(`### ${heading}`));
 
+            const lightHeadings = ['目的', '対象', '受け入れ条件'];
+            const strictHeadings = ['背景/目的', '要件/スコープ', '受け入れ条件', 'リスクレベル', 'コスト影響', '連携'];
             const isAiTask = labels.includes('ai-task');
-            const requiredHeadings = isAiTask
-              ? ['目的', '対象', '受け入れ条件']
-              : ['背景/目的', '要件/スコープ', '受け入れ条件', 'リスクレベル', 'コスト影響', '連携'];
-
-            const valid = hasAll(requiredHeadings);
+            const valid = isAiTask
+              ? hasAll(lightHeadings)
+              : hasAll(lightHeadings) || hasAll(strictHeadings);
             const needsTemplateLabel = 'needs-template';
             const addNeedsTemplateLabel = async () => {
               try {
@@ -87,16 +87,31 @@ jobs:
             );
 
             if (!alreadyCommented) {
-              const commentBody = [
-                marker,
-                `このIssueはテンプレートの必須項目が不足しているため、\`${needsTemplateLabel}\` を付けました。`,
-                '',
-                'Issue FormsまたはCLI用テンプレートを使い、少なくとも以下の見出しを含めてください。',
-                '',
-                ...requiredHeadings.map((heading) => `- \`### ${heading}\``),
-                '',
-                'AIで下書きした場合も、人間が内容を確認してテンプレート形式に整えてから次工程へ進めてください。',
-              ].join('\n');
+              const commentBody = isAiTask
+                ? [
+                    marker,
+                    `このIssueはテンプレートの必須項目が不足しているため、\`${needsTemplateLabel}\` を付けました。`,
+                    '',
+                    'AI支援タスクIssueでは、少なくとも以下の見出しを含めてください。',
+                    '',
+                    ...lightHeadings.map((heading) => `- \`### ${heading}\``),
+                    '',
+                    'AIで下書きした場合も、人間が内容を確認してテンプレート形式に整えてから次工程へ進めてください。',
+                  ].join('\n')
+                : [
+                    marker,
+                    `このIssueはテンプレートの必須項目が不足しているため、\`${needsTemplateLabel}\` を付けました。`,
+                    '',
+                    '通常Issueでは、軽運用または厳密運用のどちらかの見出しセットを満たしてください。',
+                    '',
+                    '軽運用の最小項目:',
+                    ...lightHeadings.map((heading) => `- \`### ${heading}\``),
+                    '',
+                    '厳密運用の項目:',
+                    ...strictHeadings.map((heading) => `- \`### ${heading}\``),
+                    '',
+                    'AIで下書きした場合も、人間が内容を確認してテンプレート形式に整えてから次工程へ進めてください。',
+                  ].join('\n');
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -106,4 +121,8 @@ jobs:
               });
             }
 
-            core.setFailed(`Issue body is missing required template headings: ${requiredHeadings.join(', ')}`);
+            core.setFailed(
+              isAiTask
+                ? `Issue body is missing required template headings: ${lightHeadings.join(', ')}`
+                : `Issue body must satisfy either light headings (${lightHeadings.join(', ')}) or strict headings (${strictHeadings.join(', ')})`
+            );


### PR DESCRIPTION
## 目的 *必須*

軽運用のIssueを `CONTRIBUTING.md` のルールどおりに起票しても `needs-template` 扱いにならないよう、Issue Template Check を方針に合わせる。

## 変更内容 *必須*

通常Issueで、軽運用の最小見出しまたは厳密運用の見出しセットのどちらでも通るようにした。
**変更タイプ**: type:infra

## 影響範囲 *必須*

- **対象**: `.github/workflows/issue-template-check.yml` のIssue本文検証ロジック
- **非対象**: PR Check、Issue Forms本体、ラベル定義

## 影響チェック *必須*
- [x] **ダウンタイム**: なし / 計画済み
- [x] **コスト影響**: なし / 小 / 中 / 大
- [x] **リスク**: Low / Medium / High

<details>
<summary>詳細（該当時のみ必須）</summary>

**ダウンタイム詳細**（計画ありの場合）:
**コスト根拠**（小/中/大の場合）:
**リスク根拠**（Medium/Highの場合）: GitHub Actions の Issue チェック挙動が変わるため、軽運用/厳密運用の両方で期待どおりに通ることを確認する必要がある。

</details>

## 可観測性/検証 *条件付き*

- `yaml.safe_load` で workflow のYAML構文を確認
- ローカルの簡易スクリプトで軽運用/厳密運用の両方が valid になることを確認
- `git diff --check` を確認

## ロールバック *条件付き*

このPRを revert して従来の厳密見出しのみ必須の挙動に戻す。

## 承認/リリース連携 *推奨*
- **必須承認者**: なし
- **リリースノート**: 不要
- **推奨ラベル**: type:infra, area:ci-cd, risk:medium, cost:none

<details>
<summary>テスト結果/検証手順</summary>

- `python3` で `.github/workflows/issue-template-check.yml` のYAMLを読み込み
- `node` で軽運用見出しセットと厳密運用見出しセットの両方を検証

</details>

## メモ（レビューポイント）

- `ai-task` の既存挙動を崩していないか
- 通常Issueで軽運用/厳密運用のどちらも許容するコメント文になっているか

Closes #87
