### PR TITLE
fix: restore terraform validate for ecs and rds modules

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -72,7 +72,6 @@ module "ecs" {
   source = "../../modules/compute/ecs"
 
   project_name                = var.project_name
-  environment                 = var.environment
   aws_region                  = var.aws_region
   ecr_repository_url          = var.ecr_repository_url
   container_port              = var.container_port
@@ -80,7 +79,6 @@ module "ecs" {
   cpu                         = var.cpu
   memory                      = var.memory
   client_url_for_cors         = var.client_url_for_cors
-  db_username                 = var.db_username
   db_name                     = var.db_name
   db_credentials_secret_arn   = module.rds.master_user_secret_arn
   ecs_task_execution_role_arn = module.iam.ecs_task_execution_role_arn

--- a/terraform/modules/storage/rds/main.tf
+++ b/terraform/modules/storage/rds/main.tf
@@ -1,4 +1,11 @@
 
+locals {
+  backup_retention_days = var.environment == "prod" ? 30 : 7
+  enable_multi_az       = var.environment == "prod"
+  enable_backup         = var.environment == "prod"
+  deletion_protection   = var.environment == "prod"
+}
+
 # --- RDS Subnet Group ---
 resource "aws_db_subnet_group" "postgres" {
   name       = "${var.project_name}-db-subnet-group"


### PR DESCRIPTION
## 目的 *必須*

既存の `terraform validate` エラーを解消して、required check の `Terraform Format & Validate` を再び通る状態に戻す。

## 変更内容 *必須*

`ecs` モジュール呼び出しの不要引数を削除し、`rds` モジュールに欠落していた環境別 locals を追加した。
**変更タイプ**: type:infra

## 影響範囲 *必須*

- **対象**: `terraform/environments/dev/main.tf`、`terraform/modules/storage/rds/main.tf`
- **非対象**: ECS/RDS 以外のモジュール、GitHub Actions 定義

## 影響チェック *必須*
- [x] **ダウンタイム**: なし / 計画済み
- [x] **コスト影響**: なし / 小 / 中 / 大
- [x] **リスク**: Low / Medium / High

<details>
<summary>詳細（該当時のみ必須）</summary>

**ダウンタイム詳細**（計画ありの場合）:
**コスト根拠**（小/中/大の場合）:
**リスク根拠**（Medium/Highの場合）: Terraform の環境別設定が変わるため、`dev` validate が通ることと `prod` 向け条件分岐が妥当であることを確認する必要がある。

</details>

## 可観測性/検証 *条件付き*

- `terraform init -backend=false`
- `terraform validate`
- pre-commit の `terraform fmt` / `terraform validate with tflint`

## ロールバック *条件付き*

このPRを revert し、必要なら ECS/RDS モジュールの入力仕様を別PRで再設計する。

## 承認/リリース連携 *推奨*
- **必須承認者**: なし
- **リリースノート**: 不要
- **推奨ラベル**: type:infra, area:infra, risk:medium, cost:none

<details>
<summary>テスト結果/検証手順</summary>

- `terraform -chdir=terraform/environments/dev init -backend=false`
- `terraform -chdir=terraform/environments/dev validate`
- commit 時の pre-commit チェック通過を確認

</details>

## メモ（レビューポイント）

- `ecs` への `environment` / `db_username` が本当に不要な入力か
- `rds` の環境別 locals が既存ドキュメントの意図とズレていないか

Closes #89
