### PR TITLE
docs: add post-merge local Git cleanup steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,8 +181,23 @@ gh done XX
 
 ```bash
 gh pr merge XX --merge
-git checkout main
+git switch main
 git pull origin main
+```
+
+#### ローカル作業ブランチの整理
+
+PRをマージしたら、ローカルも `main` に戻して最新化します。
+
+```bash
+git switch main
+git pull origin main
+```
+
+不要になったローカル作業ブランチは削除して構いません。
+
+```bash
+git branch -d XX-description
 ```
 
 ---


### PR DESCRIPTION
## 目的

GitHub上でPRをマージしたあと、ローカルブランチは自動では追従しないことを前提に、`CONTRIBUTING.md` に後処理手順を明記する。

## 変更内容

- PRマージ後のローカル手順を追記
- `git switch main`
- `git pull origin main`
- 不要になったローカル作業ブランチの削除例 `git branch -d XX-description`

## 影響範囲

- contributor 向け運用文書のみ
- CI / Terraform / アプリコードへの影響なし

## Issue

Closes #94
