### PR TITLE
docs: clarify labels in issue and PR plans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ CLI / API / AI Agent からIssueを作ること自体は許容します。
 `needs-template` が付いたIssueは、着手やPR作成の対象にしません。
 
 AI Agent を使う場合は、いきなり起票せずに先に Issue プランを提示し、人間が確認してから起票します。
-Issue プランには、少なくともタイトル案、`目的`、`対象`、`受け入れ条件`、`type/area/risk/cost` の見立てを含めてください。
+Issue プランには、少なくともタイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost` を明示して含めてください。
 
 ---
 
@@ -124,7 +124,7 @@ gh pr create --title "docs: update contributing guide" \
 - `PR: <type>: <変更の要約>`
 
 AI Agent を使う場合は、PR もいきなり作成せず、先に PR プランを提示して人間が確認してから作成します。
-PR プランには、少なくともタイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、`type/area/risk/cost` の見立てを含めてください。
+PR プランには、少なくともタイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost` を明示して含めてください。
 
 **PR本文のIssueリンク規則**:
 - `Closes #<issue番号>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,8 +181,23 @@ gh done XX
 
 ```bash
 gh pr merge XX --merge
-git checkout main
+git switch main
 git pull origin main
+```
+
+#### ローカル作業ブランチの整理
+
+PRをマージしたら、ローカルも `main` に戻して最新化します。
+
+```bash
+git switch main
+git pull origin main
+```
+
+不要になったローカル作業ブランチは削除して構いません。
+
+```bash
+git branch -d XX-description
 ```
 
 ---

--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -47,9 +47,9 @@
 
 - 通常Issueも AI Agent / CLI / API から起票される前提で設計する
 - ただし、AI Agent は原則として起票前に Issue プランを提示する
-- Issue プランには、タイトル案、`目的`、`対象`、`受け入れ条件`、`type/area/risk/cost` の見立てを含める
+- Issue プランには、タイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost` を明示して含める
 - PR も同様に、いきなり作成せず先に PR プランを提示する
-- PR プランには、タイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、`type/area/risk/cost` の見立て、厳密運用PRかどうか、`ロールバック` が必須かどうかを含める
+- PR プランには、タイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost`、厳密運用PRかどうか、`ロールバック` が必須かどうかを明示して含める
 - 起票後は GitHub Actions が最終チェックする
 
 Issue / PR のどちらも、AI Agent は下書きと整理を担当し、人間が起票前に内容を確認します。これにより、GitHub Actions の機械チェックに入る前に、意図のズレや過不足を減らします。


### PR DESCRIPTION
## 目的

AI Agent が Issue プランや PR プランを提示する時に、`type / area / risk / cost` を省かないよう、docs 上でも「推奨ラベルを明示して含める」ことをはっきりさせる。

## 変更内容

- `CONTRIBUTING.md` の Issue / PR プラン説明を更新
- `docs/operations/github-flow-guardrails.md` の AI Agent 運用説明を更新
- `type / area / risk / cost` を単なる見立てではなく、推奨ラベルとして明示して含めると読める表現へ揃える

## 影響範囲

- contributor 向け運用文書のみ
- CI / Terraform / アプリコードへの影響なし

## Issue

Closes #96
