### PR TITLE
dx: automate required labels for issue creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,13 @@ CloudFront (CDN) → ALB → ECS Fargate (Blue/Green) → RDS PostgreSQL
 - CLI例（feature request テンプレート）:
 
   ```bash
-  gh issue create --body-file docs/issue-templates/feature_request.md --label "type:docs,area:docs,risk:low,cost:none"
+  ./scripts/github/create-issue-with-labels.sh \
+    --title "[Docs] 要約" \
+    --body-file docs/issue-templates/feature_request.md \
+    --type type:docs \
+    --area area:docs \
+    --risk risk:low \
+    --cost cost:none
   ```
 
   CLI でテンプレ本文を扱う場合は `.github/tmp/` 配下に一時ファイルを作成し、起票後すぐ削除すること（例: `.github/tmp/issue-<summary>.md`）。
@@ -130,8 +136,13 @@ nestjs-hannibal-3/
 ### 1. Issue作成（必須第一ステップ）
 
 ```bash
-gh issue create --body-file docs/issue-templates/feature_request.md \
-  --label "type:feature,area:backend,risk:low,cost:none"
+./scripts/github/create-issue-with-labels.sh \
+  --title "[Feature] 要約" \
+  --body-file docs/issue-templates/feature_request.md \
+  --type type:feature \
+  --area area:backend \
+  --risk risk:low \
+  --cost cost:none
 ```
 
 **必須ラベル4種類:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,16 @@
 軽運用でもIssueは必須です。ただし簡潔で構いません。
 
 ```bash
-gh issue create --title "[Infra] 短い要約" \
+./scripts/github/create-issue-with-labels.sh \
+  --title "[Infra] 短い要約" \
   --body-file docs/issue-templates/feature_request.md \
-  --label "type:feature,area:infra,risk:low,cost:none"
+  --type type:feature \
+  --area area:infra \
+  --risk risk:low \
+  --cost cost:none
 ```
+
+CLI からの Issue 作成は、必須ラベルの付け忘れを防ぐため、原則として上記ヘルパーを使います。
 
 **Issueテンプレート**:
 - `.github/ISSUE_TEMPLATE/feature_request.yml` (Web UI用)
@@ -207,7 +213,13 @@ git branch -d XX-description
 mainブランチから次のIssue用ブランチを作成します。
 
 ```bash
-gh issue create --title "[Type] 次のタスク"
+./scripts/github/create-issue-with-labels.sh \
+  --title "[Type] 次のタスク" \
+  --body-file docs/issue-templates/feature_request.md \
+  --type type:docs \
+  --area area:docs \
+  --risk risk:low \
+  --cost cost:none
 git checkout -b YY-next-task
 ```
 
@@ -258,7 +270,7 @@ git checkout -b YY-next-task
 ```
 ┌─────────────────────────────────────────────┐
 │ 1. Issue作成                                 │
-│    gh issue create --title "..."             │
+│    ./scripts/github/create-issue-with-labels.sh ... │
 └───────────────┬─────────────────────────────┘
                 │
                 ▼
@@ -382,7 +394,13 @@ gh alias set done '!f() { gh pr merge "$1" --merge && git checkout main && git p
 質問や提案がある場合は、Issueを作成してください。
 
 ```bash
-gh issue create --title "[Question] 質問内容"
+./scripts/github/create-issue-with-labels.sh \
+  --title "[Question] 質問内容" \
+  --body-file docs/issue-templates/feature_request.md \
+  --type type:docs \
+  --area area:docs \
+  --risk risk:low \
+  --cost cost:none
 ```
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,9 @@
 ### deployment/
 - **deploy-codedeploy.ps1** - CodeDeploy Blue/Greenデプロイメントスクリプト
 
+### github/
+- **create-issue-with-labels.sh** - 必須4ラベル付きで Issue を作成するヘルパー
+
 ## 🚀 今後の拡張予定
 
 ### setup/
@@ -24,6 +27,8 @@
 ## 📋 使用方法
 
 各ディレクトリのREADMEを参照してください。
+
+GitHub 運用用スクリプトの使い方は [CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。
 
 ## 🔐 権限要件
 

--- a/scripts/github/create-issue-with-labels.sh
+++ b/scripts/github/create-issue-with-labels.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  create-issue-with-labels.sh \
+    --title "Issue title" \
+    --body-file path/to/body.md \
+    --type type:docs \
+    --area area:docs \
+    --risk risk:low \
+    --cost cost:none
+
+Required:
+  --title       Issue title
+  --body-file   Markdown body file passed to gh issue create
+  --type        Exactly one type:* label
+  --area        One or more area:* labels
+  --risk        Exactly one risk:* label
+  --cost        Exactly one cost:* label
+
+Notes:
+  - Repeat --area for multiple area labels.
+  - The script creates the issue first, then applies labels with gh issue edit.
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_prefix() {
+  local value="$1"
+  local prefix="$2"
+
+  if [[ "$value" != "$prefix"* ]]; then
+    die "Expected label '$value' to start with '$prefix'"
+  fi
+}
+
+title=""
+body_file=""
+type_label=""
+risk_label=""
+cost_label=""
+declare -a area_labels=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      [[ $# -ge 2 ]] || die "--title requires a value"
+      title="$2"
+      shift 2
+      ;;
+    --body-file)
+      [[ $# -ge 2 ]] || die "--body-file requires a value"
+      body_file="$2"
+      shift 2
+      ;;
+    --type)
+      [[ $# -ge 2 ]] || die "--type requires a value"
+      type_label="$2"
+      shift 2
+      ;;
+    --area)
+      [[ $# -ge 2 ]] || die "--area requires a value"
+      area_labels+=("$2")
+      shift 2
+      ;;
+    --risk)
+      [[ $# -ge 2 ]] || die "--risk requires a value"
+      risk_label="$2"
+      shift 2
+      ;;
+    --cost)
+      [[ $# -ge 2 ]] || die "--cost requires a value"
+      cost_label="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$title" ]] || die "--title is required"
+[[ -n "$body_file" ]] || die "--body-file is required"
+[[ -f "$body_file" ]] || die "Body file not found: $body_file"
+[[ -n "$type_label" ]] || die "--type is required"
+[[ ${#area_labels[@]} -ge 1 ]] || die "At least one --area is required"
+[[ -n "$risk_label" ]] || die "--risk is required"
+[[ -n "$cost_label" ]] || die "--cost is required"
+
+require_prefix "$type_label" "type:"
+require_prefix "$risk_label" "risk:"
+require_prefix "$cost_label" "cost:"
+for area_label in "${area_labels[@]}"; do
+  require_prefix "$area_label" "area:"
+done
+
+issue_url=$(
+  gh issue create \
+    --title "$title" \
+    --body-file "$body_file"
+)
+
+issue_number="${issue_url##*/}"
+
+edit_args=(
+  issue edit "$issue_number"
+  --add-label "$type_label"
+  --add-label "$risk_label"
+  --add-label "$cost_label"
+)
+
+for area_label in "${area_labels[@]}"; do
+  edit_args+=(--add-label "$area_label")
+done
+
+gh "${edit_args[@]}"
+
+printf 'Created issue #%s\n%s\n' "$issue_number" "$issue_url"


### PR DESCRIPTION
## 目的

AI Agent / CLI で Issue を作る時の `type / area / risk / cost` ラベル付け忘れを防ぐ。
Issue 作成手順をヘルパー経由へ寄せて、`needs-template` に落ちる初歩的なミスを減らす。

## 変更内容

- `scripts/github/create-issue-with-labels.sh` を追加
- `gh issue create` のあとに `gh issue edit` で必須4ラベルを付与する流れを実装
- `--type` `--area` `--risk` `--cost` の必須引数チェックを追加
- `--area` の複数指定をサポート
- `CONTRIBUTING.md` の Issue 作成例をヘルパー前提へ更新
- `.github/copilot-instructions.md` の CLI 例もヘルパー前提へ更新
- `scripts/README.md` に GitHub 用ヘルパーを追記

## 影響範囲

- Issue 起票フローと contributor 向け文書
- CI / Terraform / アプリコードへの影響なし

## Issue

Closes #98
