### PR TITLE
dx: automate required labels for PR creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,9 +56,15 @@ CloudFront (CDN) → ALB → ECS Fargate (Blue/Green) → RDS PostgreSQL
 - PowerShell推奨例（Issue番号自動埋め込み）:
 
   ```powershell
-  gh pr create --title "[Docs] 要約" `
-    --body "$(Get-Content .github/pull_request_template.md -Raw)`n`nCloses #XX" `
-    --label type:docs --label area:docs --label risk:low --label cost:none
+  ./scripts/github/create-pr-with-labels.sh `
+    --title "[Docs] 要約" `
+    --body-file .github/pull_request_template.md `
+    --issue XX `
+    --type type:docs `
+    --area area:docs `
+    --risk risk:low `
+    --cost cost:none `
+    --base main
   ```
 
 テンプレートを外した状態でのIssue/PR作成は禁止。例外が必要な場合は事前にオーナーへ相談し、承認を得ること。
@@ -163,9 +169,15 @@ git commit -m "feat: 新機能を追加"  # Conventional Commits
 ### 3. PR作成（PowerShell推奨）
 
 ```powershell
-gh pr create --title "[Feature] 要約" `
-  --body "$(Get-Content .github/pull_request_template.md -Raw)`n`nCloses #XX" `
-  --label type:feature --label area:backend --label risk:low --label cost:none
+./scripts/github/create-pr-with-labels.sh `
+  --title "[Feature] 要約" `
+  --body-file .github/pull_request_template.md `
+  --issue XX `
+  --type type:feature `
+  --area area:backend `
+  --risk risk:low `
+  --cost cost:none `
+  --base main
 ```
 
 ### 4. マージ & 自動クリーンアップ

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,17 +114,32 @@ PRテンプレートを使ってPRを作成します。
 
 **PowerShell推奨例**:
 ```powershell
-gh pr create --title "docs: update contributing guide" `
-  --body "$(Get-Content .github/pull_request_template.md -Raw)`n`nCloses #XX" `
-  --label type:feature --label area:backend --label risk:low --label cost:none
+./scripts/github/create-pr-with-labels.sh `
+  --title "docs: update contributing guide" `
+  --body-file .github/pull_request_template.md `
+  --issue XX `
+  --type type:feature `
+  --area area:backend `
+  --risk risk:low `
+  --cost cost:none `
+  --base main
 ```
 
 **bash/zsh例**:
 ```bash
-gh pr create --title "docs: update contributing guide" \
-  --body "$(cat .github/pull_request_template.md)"$'\n\n'"Closes #XX" \
-  --label type:feature --label area:backend --label risk:low --label cost:none
+./scripts/github/create-pr-with-labels.sh \
+  --title "docs: update contributing guide" \
+  --body-file .github/pull_request_template.md \
+  --issue XX \
+  --type type:feature \
+  --area area:backend \
+  --risk risk:low \
+  --cost cost:none \
+  --base main
 ```
+
+CLI からの PR 作成は、必須ラベルの付け忘れを防ぐため、原則として上記ヘルパーを使います。
+このヘルパーは `Closes #<issue番号>` を PR 本文へ自動で追記します。
 
 **PRタイトル命名規則**:
 - `PR: <type>: <変更の要約>`
@@ -294,7 +309,7 @@ git checkout -b YY-next-task
                 ▼
 ┌─────────────────────────────────────────────┐
 │ 5. PR作成                                    │
-│    gh pr create --title "..." --base main    │
+│    ./scripts/github/create-pr-with-labels.sh ... │
 └───────────────┬─────────────────────────────┘
                 │
                 ▼

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@
 
 ### github/
 - **create-issue-with-labels.sh** - 必須4ラベル付きで Issue を作成するヘルパー
+- **create-pr-with-labels.sh** - 必須4ラベル付きで PR を作成するヘルパー
 
 ## 🚀 今後の拡張予定
 

--- a/scripts/github/create-pr-with-labels.sh
+++ b/scripts/github/create-pr-with-labels.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  create-pr-with-labels.sh \
+    --title "PR title" \
+    --body-file path/to/body.md \
+    --issue 123 \
+    --type type:infra \
+    --area area:ci-cd \
+    --risk risk:low \
+    --cost cost:none \
+    [--area area:docs] \
+    [--base main] \
+    [--head my-branch]
+
+Required:
+  --title       PR title
+  --body-file   Markdown body file passed to gh pr create
+  --issue       Linked issue number appended as Closes #<number>
+  --type        Exactly one type:* label
+  --area        One or more area:* labels
+  --risk        Exactly one risk:* label
+  --cost        Exactly one cost:* label
+
+Optional:
+  --base        Base branch (default: main)
+  --head        Head branch (default: current branch)
+
+Notes:
+  - Repeat --area for multiple area labels.
+  - The script appends Closes #<issue> to the PR body automatically.
+  - The script creates the PR first, then applies labels with gh issue edit.
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_prefix() {
+  local value="$1"
+  local prefix="$2"
+
+  if [[ "$value" != "$prefix"* ]]; then
+    die "Expected label '$value' to start with '$prefix'"
+  fi
+}
+
+title=""
+body_file=""
+type_label=""
+risk_label=""
+cost_label=""
+base_branch="main"
+head_branch=""
+linked_issue=""
+declare -a area_labels=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      [[ $# -ge 2 ]] || die "--title requires a value"
+      title="$2"
+      shift 2
+      ;;
+    --body-file)
+      [[ $# -ge 2 ]] || die "--body-file requires a value"
+      body_file="$2"
+      shift 2
+      ;;
+    --type)
+      [[ $# -ge 2 ]] || die "--type requires a value"
+      type_label="$2"
+      shift 2
+      ;;
+    --issue)
+      [[ $# -ge 2 ]] || die "--issue requires a value"
+      linked_issue="$2"
+      shift 2
+      ;;
+    --area)
+      [[ $# -ge 2 ]] || die "--area requires a value"
+      area_labels+=("$2")
+      shift 2
+      ;;
+    --risk)
+      [[ $# -ge 2 ]] || die "--risk requires a value"
+      risk_label="$2"
+      shift 2
+      ;;
+    --cost)
+      [[ $# -ge 2 ]] || die "--cost requires a value"
+      cost_label="$2"
+      shift 2
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || die "--base requires a value"
+      base_branch="$2"
+      shift 2
+      ;;
+    --head)
+      [[ $# -ge 2 ]] || die "--head requires a value"
+      head_branch="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$title" ]] || die "--title is required"
+[[ -n "$body_file" ]] || die "--body-file is required"
+[[ -f "$body_file" ]] || die "Body file not found: $body_file"
+[[ -n "$linked_issue" ]] || die "--issue is required"
+[[ -n "$type_label" ]] || die "--type is required"
+[[ ${#area_labels[@]} -ge 1 ]] || die "At least one --area is required"
+[[ -n "$risk_label" ]] || die "--risk is required"
+[[ -n "$cost_label" ]] || die "--cost is required"
+
+[[ "$linked_issue" =~ ^[0-9]+$ ]] || die "--issue must be a numeric issue number"
+require_prefix "$type_label" "type:"
+require_prefix "$risk_label" "risk:"
+require_prefix "$cost_label" "cost:"
+for area_label in "${area_labels[@]}"; do
+  require_prefix "$area_label" "area:"
+done
+
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+
+cat "$body_file" > "$tmp_body"
+printf '\n\nCloses #%s\n' "$linked_issue" >> "$tmp_body"
+
+create_args=(
+  pr create
+  --title "$title"
+  --body-file "$tmp_body"
+  --base "$base_branch"
+)
+
+if [[ -n "$head_branch" ]]; then
+  create_args+=(--head "$head_branch")
+fi
+
+pr_url=$(gh "${create_args[@]}")
+pr_number="${pr_url##*/}"
+
+edit_args=(
+  issue edit "$pr_number"
+  --add-label "$type_label"
+  --add-label "$risk_label"
+  --add-label "$cost_label"
+)
+
+for area_label in "${area_labels[@]}"; do
+  edit_args+=(--add-label "$area_label")
+done
+
+gh "${edit_args[@]}"
+
+printf 'Created PR #%s\n%s\n' "$pr_number" "$pr_url"


### PR DESCRIPTION
## 目的

AI Agent / CLI で PR を作る時の `type / area / risk / cost` ラベル付け忘れを防ぐ。
合わせて、`Closes #<issue番号>` の付け忘れも減らせるよう、PR本文の組み立てをヘルパーへ寄せる。

## 変更内容

- `scripts/github/create-pr-with-labels.sh` を追加
- `--issue` を必須にして、PR本文末尾へ `Closes #<番号>` を自動追記
- `gh pr create` のあとに `gh issue edit <PR番号>` で必須4ラベルを付与
- `--type` `--area` `--risk` `--cost` の必須引数チェックを追加
- `--area` の複数指定をサポート
- `CONTRIBUTING.md` と `.github/copilot-instructions.md` の PR 作成例をヘルパー前提へ更新
- `scripts/README.md` に PR ヘルパーを追記

## 影響範囲

- PR 起票フローと contributor 向け文書
- CI / Terraform / アプリコードへの影響なし


Closes #100
