### PR TITLE
dx: reinforce helper guidance in docs and CI

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -133,6 +133,8 @@ jobs:
                 '- `risk:*` をちょうど1つ',
                 '- `cost:*` をちょうど1つ',
                 '',
+                'CLI や AI Agent から起票する場合は `./scripts/github/create-issue-with-labels.sh` を使うと、必須ラベルの付け忘れを減らせます。',
+                '',
                 'AIで下書きした場合も、人間が内容を確認してテンプレート形式に整えてから次工程へ進めてください。',
               ].join('\n');
 
@@ -153,7 +155,7 @@ jobs:
                   ? `Issue body sections must not be empty: ${emptyHeadings.join(', ')}`
                   : null,
                 labelErrors.length > 0
-                  ? `Issue labels must include ${labelErrors.join(', ')}`
+                  ? `Issue labels must include ${labelErrors.join(', ')}. Use ./scripts/github/create-issue-with-labels.sh to create labeled issues from CLI or AI Agent workflows.`
                   : null,
               ]
                 .filter(Boolean)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -48,22 +48,22 @@ jobs:
           strict_by_cost=$(printf '%s\n' "$counts" | sed -n '6p')
 
           if [ "$type_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one type:* label."
+            echo "::error::PR must have exactly one type:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
             exit 1
           fi
 
           if [ "$area_count" -lt 1 ]; then
-            echo "::error::PR must have at least one area:* label."
+            echo "::error::PR must have at least one area:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
             exit 1
           fi
 
           if [ "$risk_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one risk:* label."
+            echo "::error::PR must have exactly one risk:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
             exit 1
           fi
 
           if [ "$cost_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one cost:* label."
+            echo "::error::PR must have exactly one cost:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
             exit 1
           fi
 
@@ -81,7 +81,7 @@ jobs:
           if printf '%s\n' "$PR_BODY" | grep -Eiq '(close[sd]?|fix(e[sd])?|refs?) #[0-9]+'; then
             echo "Linked issue found."
           else
-            echo "::error::PR body must include a linked issue, for example: Closes #123, Fixes #123, or Refs #123"
+            echo "::error::PR body must include a linked issue, for example: Closes #123, Fixes #123, or Refs #123. ./scripts/github/create-pr-with-labels.sh appends Closes #<issue番号> automatically."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,18 @@
 
 ## 🚀 開発フロー（Issue駆動開発）
 
+### 正規コマンド
+
+Issue と PR の作成は、原則として以下のヘルパーを使います。
+
+```bash
+# Issue
+./scripts/github/create-issue-with-labels.sh ...
+
+# PR
+./scripts/github/create-pr-with-labels.sh ...
+```
+
 ### 1. Issue作成
 
 新しい機能追加やバグ修正は、必ずIssueから始めます。
@@ -49,7 +61,7 @@ CLI / API / AI Agent からIssueを作ること自体は許容します。
 `needs-template` が付いたIssueは、着手やPR作成の対象にしません。
 
 AI Agent を使う場合は、いきなり起票せずに先に Issue プランを提示し、人間が確認してから起票します。
-Issue プランには、少なくともタイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost` を明示して含めてください。
+Issue プランには、少なくともタイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost`、`使用ヘルパー: ./scripts/github/create-issue-with-labels.sh` を明示して含めてください。
 
 ---
 
@@ -145,7 +157,7 @@ CLI からの PR 作成は、必須ラベルの付け忘れを防ぐため、原
 - `PR: <type>: <変更の要約>`
 
 AI Agent を使う場合は、PR もいきなり作成せず、先に PR プランを提示して人間が確認してから作成します。
-PR プランには、少なくともタイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost` を明示して含めてください。
+PR プランには、少なくともタイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost`、`使用ヘルパー: ./scripts/github/create-pr-with-labels.sh` を明示して含めてください。
 
 **PR本文のIssueリンク規則**:
 - `Closes #<issue番号>`

--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -47,9 +47,9 @@
 
 - 通常Issueも AI Agent / CLI / API から起票される前提で設計する
 - ただし、AI Agent は原則として起票前に Issue プランを提示する
-- Issue プランには、タイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost` を明示して含める
+- Issue プランには、タイトル案、`目的`、`対象`、`受け入れ条件`、推奨ラベルとしての `type/area/risk/cost`、`使用ヘルパー: ./scripts/github/create-issue-with-labels.sh` を明示して含める
 - PR も同様に、いきなり作成せず先に PR プランを提示する
-- PR プランには、タイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost`、厳密運用PRかどうか、`ロールバック` が必須かどうかを明示して含める
+- PR プランには、タイトル案、`目的`、`変更内容`、`影響範囲`、`Closes/Fixes/Refs #<issue番号>`、推奨ラベルとしての `type/area/risk/cost`、`使用ヘルパー: ./scripts/github/create-pr-with-labels.sh`、厳密運用PRかどうか、`ロールバック` が必須かどうかを明示して含める
 - 起票後は GitHub Actions が最終チェックする
 
 Issue / PR のどちらも、AI Agent は下書きと整理を担当し、人間が起票前に内容を確認します。これにより、GitHub Actions の機械チェックに入る前に、意図のズレや過不足を減らします。


### PR DESCRIPTION
## 目的

Issue / PR 作成時の正規ヘルパーを、docs と CI 失敗メッセージの両方から見つけやすくする。
AI Agent が `CONTRIBUTING.md` を見落としても、失敗時に正しい経路へ戻りやすい状態を作る。

## 変更内容

- `CONTRIBUTING.md` に Issue / PR の正規コマンドを先頭近くで明示
- Issue プランに `使用ヘルパー: ./scripts/github/create-issue-with-labels.sh` を追加
- PR プランに `使用ヘルパー: ./scripts/github/create-pr-with-labels.sh` を追加
- `docs/operations/github-flow-guardrails.md` にも同じ方針を反映
- Issue チェック失敗時コメントと失敗メッセージに Issue ヘルパー名を追記
- PR チェック失敗時メッセージに PR ヘルパー名を追記

## 影響範囲

- contributor 向け運用文書
- GitHub Actions のガードレールメッセージ
- Terraform / アプリコードへの影響なし

## ロールバック

- このPRを revert して、`CONTRIBUTING.md`、`docs/operations/github-flow-guardrails.md`、`.github/workflows/issue-template-check.yml`、`.github/workflows/pr-check.yml` の変更を元に戻す。
- これにより、ヘルパー案内の追加前の docs / CI メッセージへ戻せる。

Closes #102
