### PR TITLE
docs: add Codex log extraction guide

### DIFF
--- a/docs/operations/codex-log-extract.md
+++ b/docs/operations/codex-log-extract.md
@@ -1,0 +1,18 @@
+# Codexログ抽出手順
+
+## 概要
+
+CodexのJSONLログから user / assistant の会話のみを抽出してMarkdownとして保存する。
+
+## 手順
+
+```bash
+jq -r '
+  select(.type=="response_item" and .payload.type=="message")
+  | select(.payload.role=="user" or .payload.role=="assistant")
+  | "\n## " + (if .payload.role=="user" then "🧑 User" else "🤖 Assistant" end)
+    + "\n\n"
+    + ([.payload.content[].text] | join("\n"))
+' ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl \
+> ~/dev/projects/terraform-hannibal/docs/memo/codex-YYYY-MM-DD.md
+```


### PR DESCRIPTION
## 目的

Codex の JSONL ログから user / assistant の会話だけを Markdown に抽出する手順を docs に残す。

## 変更内容

- `docs/operations/codex-log-extract.md` を追加
- `jq` を使った抽出コマンド例を記載
- 出力先として `docs/memo/codex-YYYY-MM-DD.md` の例を記載

## 影響範囲

- docs のみ
- CI / Terraform / アプリコードへの影響なし


Closes #104
