### PR TITLE
docs: reorganize local worklog paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ TODO.md
 
 memo/
 drafts/
+docs/worklogs/
 
 # Local Codex workspace file
 .codex

--- a/docs/operations/codex-log-extract.md
+++ b/docs/operations/codex-log-extract.md
@@ -3,6 +3,7 @@
 ## 概要
 
 CodexのJSONLログから user / assistant の会話のみを抽出してMarkdownとして保存する。
+抽出ログは Git に載せず、ローカル専用の `docs/worklogs/<agent>/YYYY-MM-DD.md` 配下へ保存する。
 
 ## 手順
 
@@ -14,5 +15,11 @@ jq -r '
     + "\n\n"
     + ([.payload.content[].text] | join("\n"))
 ' ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl \
-> ~/dev/projects/terraform-hannibal/docs/memo/codex-YYYY-MM-DD.md
+> ~/dev/projects/terraform-hannibal/docs/worklogs/codex/YYYY-MM-DD.md
 ```
+
+## 保存先ルール
+
+- ログは `docs/worklogs/<agent>/YYYY-MM-DD.md` に置く
+- Codex の場合は `docs/worklogs/codex/YYYY-MM-DD.md`
+- `docs/worklogs/**` は `.gitignore` に入れ、GitHub には載せない


### PR DESCRIPTION
## 目的

Codex などのローカル作業ログの保存先を `docs/worklogs/<agent>/YYYY-MM-DD.md` に整理し、ログ本体は GitHub に載せない前提へ揃える。

## 変更内容

- `.gitignore` に `docs/worklogs/` を追加
- `docs/operations/codex-log-extract.md` の出力先例を `docs/worklogs/codex/YYYY-MM-DD.md` に更新
- 抽出ログは Git 管理外のローカル専用ファイルとして扱う方針を追記

## 影響範囲

- docs とローカル運用手順のみ
- CI / Terraform / アプリコードへの影響なし


Closes #108
