### PR TITLE
dx: highlight needs-template fix targets

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -120,7 +120,10 @@ jobs:
               marker,
               `このIssueは本文または必須ラベルが不足しているため、\`${needsTemplateLabel}\` を付けました。`,
               '',
-              '不足している項目:',
+              '## 要修正',
+              '',
+              'このIssueは次を修正すると通ります:',
+              '',
               ...(missingHeadings.length > 0
                 ? missingHeadings.map((heading) => `- 見出し不足: \`${heading}\``)
                 : []),
@@ -131,7 +134,7 @@ jobs:
                 ? labelErrors.map((error) => `- ラベル不足: ${error}`)
                 : []),
               '',
-              '必要条件:',
+              '## 必要条件',
               '- 本文には `目的` `対象` `受け入れ条件` を含める',
               '- 各項目には見出しだけでなく中身も書く',
               '- `type:*` をちょうど1つ',


### PR DESCRIPTION
## 目的

`needs-template` コメントで、何を直せば通るかを先頭で一目で分かるようにする。

## 変更内容

- `.github/workflows/issue-template-check.yml` の bot コメント文面を調整
- 先頭に `## 要修正` を追加
- `このIssueは次を修正すると通ります:` を追加
- 既存の具体的な原因表示は維持しつつ、必要条件ブロックを後ろへ整理

## 影響範囲

- Issue Template Check のコメント表示のみ
- CI / Terraform / アプリコードへの影響なし

## ロールバック

このPRを revert し、`.github/workflows/issue-template-check.yml` をマージ前の状態へ戻す。


Closes #113
