### PR TITLE
dx: remove generic needs-template intro

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -118,8 +118,6 @@ jobs:
 
             const commentBody = [
               marker,
-              `このIssueは本文または必須ラベルが不足しているため、\`${needsTemplateLabel}\` を付けました。`,
-              '',
               '## 要修正',
               '',
               'このIssueは次を修正すると通ります:',


### PR DESCRIPTION
## 目的

`needs-template` コメントの先頭から曖昧な汎用説明を外し、要修正項目をそのまま見せる。

## 変更内容

- `.github/workflows/issue-template-check.yml` の bot コメント先頭から汎用説明を削除
- コメントを `## 要修正` から始める形に統一
- 既存の具体的な原因表示は維持

## 影響範囲

- Issue Template Check のコメント表示のみ
- CI / Terraform / アプリコードへの影響なし

## ロールバック

このPRを revert し、`.github/workflows/issue-template-check.yml` をマージ前の状態へ戻す。


Closes #116
