### PR TITLE
PRマージ後のブランチcleanupヘルパーを追加する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,17 +222,28 @@ git pull origin main
 
 #### ローカル作業ブランチの整理
 
-PRをマージしたら、ローカルも `main` に戻して最新化します。
+PRをマージしたら、ローカルも `main` に戻して最新化し、不要になった作業ブランチを削除します。
+
+```bash
+./scripts/github/cleanup-merged-pr-branch.sh XX
+```
+
+このヘルパーは、GitHub上でPRが `MERGED` であることを確認してから、PRのhead branchを削除対象にします。squash merge後にローカルGitでは未マージに見えるブランチも、安全確認のうえで整理できます。
+
+手動で行う場合:
 
 ```bash
 git switch main
-git pull origin main
+git pull --ff-only origin main
 ```
 
-不要になったローカル作業ブランチは削除して構いません。
+不要になったローカル作業ブランチは削除して構いません。squash merge後はGit上のmerged判定とGitHub上のマージ状態がずれることがあるため、PRがマージ済みであることを確認してから削除します。
 
 ```bash
 git branch -d XX-description
+# squash merge後など、Git上は未マージに見えるがPRがマージ済みと確認できる場合
+git branch -D XX-description
+git push origin --delete XX-description
 ```
 
 ---

--- a/docs/operations/codex-log-extract.md
+++ b/docs/operations/codex-log-extract.md
@@ -3,11 +3,15 @@
 ## 概要
 
 CodexのJSONLログから user / assistant の会話のみを抽出してMarkdownとして保存する。
-抽出ログは Git に載せず、ローカル専用の `docs/worklogs/<agent>/YYYY-MM-DD.md` 配下へ保存する。
+抽出ログは Git に載せず、ローカル専用の `docs/worklogs/<agent>/` 配下へ保存する。
+ファイル名には**抽出実行時刻まで含める**（`YYYY-MM-DD-HHMMSS.md`）。同一日内にセッションが伸びたあと再実行しても、過去の抽出ファイルを上書きしない。
 
 ## 手順
 
 ```bash
+TS=$(date +%Y-%m-%d-%H%M%S)
+OUT=~/dev/projects/terraform-hannibal/docs/worklogs/codex/${TS}.md
+mkdir -p "$(dirname "$OUT")"
 jq -r '
   select(.type=="response_item" and .payload.type=="message")
   | select(.payload.role=="user" or .payload.role=="assistant")
@@ -15,11 +19,13 @@ jq -r '
     + "\n\n"
     + ([.payload.content[].text] | join("\n"))
 ' ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl \
-> ~/dev/projects/terraform-hannibal/docs/worklogs/codex/YYYY-MM-DD.md
+> "$OUT"
 ```
+
+`YYYY/MM/DD` は抽出対象セッションの日付（`~/.codex/sessions/` 下のディレクトリ）に合わせる。
 
 ## 保存先ルール
 
-- ログは `docs/worklogs/<agent>/YYYY-MM-DD.md` に置く
-- Codex の場合は `docs/worklogs/codex/YYYY-MM-DD.md`
+- ログは `docs/worklogs/<agent>/YYYY-MM-DD-HHMMSS.md` に置く
+- Codex の場合は `docs/worklogs/codex/YYYY-MM-DD-HHMMSS.md`
 - `docs/worklogs/**` は `.gitignore` に入れ、GitHub には載せない

--- a/scripts/github/cleanup-merged-pr-branch.sh
+++ b/scripts/github/cleanup-merged-pr-branch.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  cleanup-merged-pr-branch.sh <PR number>
+
+Description:
+  Cleans up the local and remote head branch for a GitHub PR after the PR is
+  confirmed as MERGED on GitHub.
+
+Safety:
+  - Does nothing when the PR is not MERGED.
+  - Refuses to delete main/master or an empty branch name.
+  - Refuses to run with a dirty worktree.
+  - Switches to the PR base branch and pulls it with --ff-only before cleanup.
+
+Example:
+  ./scripts/github/cleanup-merged-pr-branch.sh 135
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+local_branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+remote_branch_exists() {
+  git ls-remote --exit-code --heads origin "$1" >/dev/null 2>&1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+pr_number="$1"
+
+[[ "$pr_number" =~ ^[0-9]+$ ]] || die "PR number must be numeric"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "Not inside a git repository"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  die "Working tree must be clean before cleanup"
+fi
+
+pr_info="$(gh pr view "$pr_number" \
+  --json state,mergedAt,headRefName,baseRefName \
+  --jq '[.state, (.mergedAt // ""), .headRefName, .baseRefName] | @tsv')"
+
+IFS=$'\t' read -r pr_state merged_at head_branch base_branch <<<"$pr_info"
+
+if [[ "$pr_state" != "MERGED" ]]; then
+  printf 'PR #%s is %s, not MERGED. Nothing to cleanup.\n' "$pr_number" "$pr_state"
+  exit 0
+fi
+
+[[ -n "$head_branch" ]] || die "PR head branch is empty"
+[[ "$head_branch" != "main" && "$head_branch" != "master" ]] || die "Refusing to delete protected branch: $head_branch"
+[[ "$head_branch" != -* ]] || die "Refusing to delete branch starting with '-': $head_branch"
+git check-ref-format --branch "$head_branch" >/dev/null || die "Invalid branch name: $head_branch"
+
+if [[ -z "$base_branch" ]]; then
+  base_branch="main"
+fi
+
+[[ "$head_branch" != "$base_branch" ]] || die "Refusing to delete PR base branch: $base_branch"
+
+printf 'PR #%s is MERGED at %s.\n' "$pr_number" "$merged_at"
+printf 'Cleanup target branch: %s\n' "$head_branch"
+printf 'Base branch to update: %s\n' "$base_branch"
+
+current_branch="$(git branch --show-current)"
+
+if [[ "$current_branch" != "$base_branch" ]]; then
+  run git switch "$base_branch"
+fi
+
+run git pull --ff-only origin "$base_branch"
+
+if local_branch_exists "$head_branch"; then
+  run git branch -D "$head_branch"
+else
+  printf 'Local branch %s does not exist. Skipping local cleanup.\n' "$head_branch"
+fi
+
+if remote_branch_exists "$head_branch"; then
+  run git push origin --delete "$head_branch"
+else
+  printf 'Remote branch origin/%s does not exist. Skipping remote cleanup.\n' "$head_branch"
+fi
+
+printf 'Cleanup complete for PR #%s.\n' "$pr_number"


### PR DESCRIPTION
## 目的（推奨）

PRをsquash/mergeした後、Git上は未マージに見える作業ブランチを、GitHub上のPRマージ状態を確認してから安全にcleanupできるようにする。

## 変更内容（推奨）

- `scripts/github/cleanup-merged-pr-branch.sh` を追加
- PR番号から `gh pr view` で `MERGED` と `headRefName` を確認してcleanupするようにした
- `CONTRIBUTING.md` のPRマージ後手順にヘルパー利用を追記

## 影響範囲（推奨）

- **対象**: ローカルGit運用補助スクリプト、CONTRIBUTINGの手順
- **非対象**: アプリケーションコード、AWS、Terraform、GitHub Actions workflow

## PRラベル（必須）

- **type**: `type:feature`
- **area**: `area:ci-cd`, `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。ローカル補助スクリプトとドキュメントのみ。
**コスト根拠**: AWSリソース作成なし。
**リスク根拠**: main/master削除拒否、PR未マージ時no-op、dirty worktree拒否を入れているため低リスク。

</details>

## 可観測性/検証 *条件付き*

- `bash -n scripts/github/cleanup-merged-pr-branch.sh`
- `./scripts/github/cleanup-merged-pr-branch.sh --help`
- `./scripts/github/cleanup-merged-pr-branch.sh abc` が入力エラーになること
- dirty worktreeで `./scripts/github/cleanup-merged-pr-branch.sh 135` が停止すること
- commit後に `./scripts/github/cleanup-merged-pr-branch.sh 135` を実行し、マージ済みPRのローカル作業ブランチをcleanupできること
- `git diff --check`
- commit時pre-commit: `Detect hardcoded secrets` passed

## ロールバック *条件付き*

このPRはローカル補助スクリプトとドキュメントのみなので、問題があればこのPRをrevertする。AWS、Terraform state、GitHub Actions workflow、mainの履歴には影響しない。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```text
bash -n scripts/github/cleanup-merged-pr-branch.sh
./scripts/github/cleanup-merged-pr-branch.sh --help
./scripts/github/cleanup-merged-pr-branch.sh abc
./scripts/github/cleanup-merged-pr-branch.sh 135
```

実動作確認では #135 が `MERGED` であることを確認し、ローカル `121-pr-plan-oidc-role-design` ブランチを削除しました。リモートブランチは既に存在しなかったためskipされました。

commit時pre-commit:

```text
Terraform fmt........................................(no files to check)Skipped
Terraform validate with tflint.......................(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
```

</details>

## メモ（レビューポイント）

- PR未マージ時に何も削除しないこと
- `main` / `master` / PR base branchを削除拒否すること
- dirty worktreeでは止めること
- remote branchが存在しない場合はskipすること


## スコープに関する注記（追記）

本ブランチはもともと **#136（マージ済み PR のローカルブランチ cleanup ヘルパー）** 向けの作業用ですが、**PR 作成済み・マージ待ちの段階で別件の変更を誤って同じブランチへプッシュ**しました。そのためこの PR には次の **二系統** の変更が含まれます。

1. **主目的**: `cleanup-merged-pr-branch.sh` の追加と `CONTRIBUTING.md` の手順追記（本文前半の「変更内容」どおり）。
2. **付随**: `docs/operations/codex-log-extract.md` の運用手順更新（出力 Markdown のファイル名に実行時刻サフィックス `YYYY-MM-DD-HHMMSS` を含める形への整理）。

付随分は **ドキュメントのみ** で、アプリケーション・Terraform・GitHub Actions には触れません。レビュー時は変更ファイル一覧でスコープが混在している点のみご留意ください。


Closes #136
