### PR TITLE
infra: add PR terraform plan IAM role

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -487,3 +487,122 @@ resource "aws_iam_role_policy_attachment" "cacoo_policy_attachment" {
   role       = aws_iam_role.cacoo_integration_role.name
   policy_arn = aws_iam_policy.cacoo_readonly_policy.arn
 }
+
+# --- 8. HannibalPRPlanRole-Dev (PR terraform plan専用ロール) ---
+# 信頼ポリシー: GitHub OIDC による AssumeRoleWithWebIdentity
+# 許可範囲: kmryst/terraform-hannibal への pull_request イベントのみ
+# 用途: PR Check での terraform plan 実行（read-only、apply/destroy 権限なし）
+# 設計詳細: docs/operations/pr-terraform-plan-role-design.md
+# Permission Boundary: 付与しない。plan policy が read-only に限定されており
+#   既存の HannibalCICDBoundary は deploy/destroy 用で流用不適。
+#   専用 Boundary の要否は Issue #139 で後続検討する。
+resource "aws_iam_role" "hannibal_pr_plan_role" {
+  name = "HannibalPRPlanRole-Dev"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = "arn:aws:iam::${var.aws_account_id}:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:kmryst/terraform-hannibal:pull_request"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# --- 9. HannibalPRPlanPolicy-Dev (PR terraform plan専用ポリシー) ---
+# terraform plan に必要な read/list/describe/get 権限のみ
+# 含めない: iam:PassRole / create・update・delete・put・modify 系 /
+#           s3:PutObject・DeleteObject / dynamodb:PutItem・DeleteItem /
+#           secretsmanager:GetSecretValue / ECR push・upload 系
+resource "aws_iam_policy" "hannibal_pr_plan_policy" {
+  name        = "HannibalPRPlanPolicy-Dev"
+  description = "Read-only permissions for PR terraform plan - describe/list/get only, no write or apply operations"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "TerraformPlanRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "ec2:Describe*",
+          "elasticloadbalancing:Describe*",
+          "ecs:Describe*",
+          "ecs:List*",
+          "ecr:DescribeRepositories",
+          "ecr:GetLifecyclePolicy",
+          "ecr:ListTagsForResource",
+          "rds:Describe*",
+          "rds:ListTagsForResource",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:ListTagsForResource",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:GetDashboard",
+          "cloudwatch:ListTagsForResource",
+          "sns:GetTopicAttributes",
+          "sns:GetSubscriptionAttributes",
+          "sns:ListSubscriptionsByTopic",
+          "sns:ListTagsForResource",
+          "sns:ListTopics",
+          "codedeploy:Get*",
+          "codedeploy:List*",
+          "iam:GetRole",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:ListInstanceProfilesForRole",
+          "s3:GetBucketLocation",
+          "s3:GetBucketPolicy",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:GetBucketVersioning",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetBucketTagging",
+          "s3:GetBucketAcl",
+          "s3:ListBucket",
+          "route53:GetHostedZone",
+          "route53:ListHostedZones",
+          "route53:ListHostedZonesByName",
+          "route53:ListResourceRecordSets",
+          "route53:ListTagsForResource",
+          "cloudfront:GetOriginAccessControl",
+          "cloudfront:ListOriginAccessControls",
+          "cloudfront:GetDistribution",
+          "cloudfront:GetDistributionConfig",
+          "cloudfront:ListTagsForResource",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:ListSecretVersionIds",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "TerraformStateRead"
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::nestjs-hannibal-3-terraform-state/environments/dev/terraform.tfstate"
+      }
+    ]
+  })
+}
+
+# --- 10. Policy Attachment (PR plan) ---
+resource "aws_iam_role_policy_attachment" "hannibal_pr_plan_policy_attachment" {
+  role       = aws_iam_role.hannibal_pr_plan_role.name
+  policy_arn = aws_iam_policy.hannibal_pr_plan_policy.arn
+}

--- a/terraform/foundation/outputs.tf
+++ b/terraform/foundation/outputs.tf
@@ -1,0 +1,6 @@
+# terraform/foundation/outputs.tf
+
+output "pr_plan_role_arn" {
+  description = "ARN of HannibalPRPlanRole-Dev for use in PR terraform plan workflow (#122)"
+  value       = aws_iam_role.hannibal_pr_plan_role.arn
+}


### PR DESCRIPTION
## 目的

PR Check で `terraform plan` を安全に実行するための専用 IAM Role
`HannibalPRPlanRole-Dev` を `terraform/foundation` に Terraform で実装する。

## 変更内容

- `terraform/foundation/iam.tf`: Section 8〜10 追加
  - `HannibalPRPlanRole-Dev`（OIDC Trust Policy: `pull_request` イベント限定）
  - `HannibalPRPlanPolicy-Dev`（read/list/describe/get 系のみ）
  - Policy Attachment
- `terraform/foundation/outputs.tf`: 新規作成
  - `pr_plan_role_arn` output（#122 から参照用）

## 影響範囲

- **対象**: `terraform/foundation` の IAM 定義（コード追加のみ。apply は PR マージ後に手動実行）
- **非対象**: `.github/workflows/`・既存の `HannibalCICDRole-Dev`・`deploy.yml`・`destroy.yml`・state backend

## 設計根拠

設計詳細は `docs/operations/pr-terraform-plan-role-design.md`（#121）を参照。

Trust Policy は `StringEquals` + `repo:kmryst/terraform-hannibal:pull_request` 固定。
ワイルドカード・GitHub Environment は使わない。

### Permission Boundary について

`HannibalPRPlanRole-Dev` に Permission Boundary は付与しない。

理由:
- Policy が read-only に限定されており、Boundary なしでも read-only が実効上限になる
- 既存の `HannibalCICDBoundary` は deploy/destroy 用（write 系 Allow）であり、
  plan-only Role に流用すると Boundary が write 系を止めない（流用は Boundary なしより危険）
- Policy 変更は terraform PR 必須の厳密運用であり、plan 差分のレビューで確認できる

専用 Boundary（`HannibalPRPlanBoundary-Dev`）の要否は Issue #139 で後続検討する。

### State 管理方針

`HannibalPRPlanRole-Dev` / `HannibalPRPlanPolicy-Dev` は foundation state で恒久管理する。
`terraform state rm` はしない。`terraform/environments/dev` の deploy/destroy には巻き込まれない。

## 可観測性/検証

```bash
terraform fmt -check -recursive
# → 差分なし

terraform -chdir=terraform/foundation init -backend=false
# → Successfully initialized

terraform -chdir=terraform/foundation validate
# → The configuration is valid.
```

terraform plan / apply は PR マージ後に人間が確認して実行する。

## ロールバック

- **PR マージ前**: ブランチ revert またはクローズ。AWS リソース未作成のため影響なし。
- **apply 済みで問題発生**:
  1. #122 workflow の plan job を無効化（未実装のため現時点では何も動かない）
  2. `HannibalPRPlanRole-Dev` から policy attachment を外す
  3. 必要に応じて Policy → Role の順で削除
  4. 既存の `HannibalCICDRole-Dev`・`deploy.yml`・`destroy.yml`・state backend には触れない

## apply コマンド案（マージ後に人間が実行）

```bash
terraform -chdir=terraform/foundation init

# 初回は -target で新リソースのみ安全に適用（推奨）
terraform -chdir=terraform/foundation apply \
  -target=aws_iam_role.hannibal_pr_plan_role \
  -target=aws_iam_policy.hannibal_pr_plan_policy \
  -target=aws_iam_role_policy_attachment.hannibal_pr_plan_policy_attachment

# state rm はしない
# foundation state で恒久管理。dev deploy/destroy には巻き込まれない。
```


Closes #127
