### PR TITLE
ci: add PR terraform plan artifact job

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,12 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [main]
 
+env:
+  AWS_ACCOUNT_ID: "258632448142"
+  AWS_REGION: "ap-northeast-1"
+  TERRAFORM_VERSION: "1.12.1"
+  NODE_VERSION: "20"
+
 jobs:
   pr-policy-check:
     name: PR Policy Check
@@ -172,3 +178,132 @@ jobs:
       - name: Terraform Validate (dev)
         working-directory: ./terraform/environments/dev
         run: terraform validate
+
+  terraform-plan-changes:
+    name: Terraform Plan Change Detection
+    runs-on: ubuntu-latest
+    outputs:
+      terraform_changed: ${{ steps.detect.outputs.terraform_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect terraform changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if printf '%s\n' "$changed_files" | grep -Eq '^terraform/'; then
+            echo "terraform_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Terraform changes detected."
+          else
+            echo "terraform_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No terraform changes detected."
+          fi
+
+  terraform-plan:
+    name: Terraform Plan Artifact
+    runs-on: ubuntu-latest
+    needs: terraform-plan-changes
+    if: needs.terraform-plan-changes.outputs.terraform_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # aws_s3_object の fileset 用。plan 前に client/dist を用意する。
+      - name: Setup Node.js for frontend build
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: Build frontend (client/dist for Terraform)
+        run: |
+          set -e
+          cd client
+          echo "VITE_GRAPHQL_ENDPOINT=/graphql" > .env.production
+          npm ci
+          npm run build
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials for PR plan
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/HannibalPRPlanRole-Dev
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (dev backend)
+        working-directory: ./terraform/environments/dev
+        run: terraform init -input=false
+
+      - name: Terraform Plan (dev)
+        id: terraform_plan
+        working-directory: ./terraform/environments/dev
+        run: |
+          set +e
+          terraform plan \
+            -refresh=true \
+            -lock=false \
+            -input=false \
+            -no-color \
+            -detailed-exitcode \
+            -var="client_url_for_cors=https://hamilcar-hannibal.click" \
+            -var="environment=dev" \
+            -var="deployment_type=canary" \
+            -var="enable_cloudfront=true" \
+            > terraform-plan.txt 2>&1
+          plan_exit=$?
+          set -e
+
+          echo "$plan_exit" > terraform-plan-exitcode.txt
+
+          if [ "$plan_exit" -eq 0 ]; then
+            echo "plan_status=no_changes" >> "$GITHUB_OUTPUT"
+            echo "Terraform plan completed with no changes."
+          elif [ "$plan_exit" -eq 2 ]; then
+            echo "plan_status=changes" >> "$GITHUB_OUTPUT"
+            echo "Terraform plan completed with changes. This is expected for a destroyed dev environment."
+          else
+            echo "plan_status=failed" >> "$GITHUB_OUTPUT"
+            echo "::error::Terraform plan failed. Check the uploaded terraform-plan-dev artifact and job logs."
+            exit "$plan_exit"
+          fi
+
+      - name: Upload Terraform plan text artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan-dev-${{ github.event.pull_request.number }}
+          path: |
+            terraform/environments/dev/terraform-plan.txt
+            terraform/environments/dev/terraform-plan-exitcode.txt
+          if-no-files-found: warn
+          retention-days: 3
+
+      - name: Write Terraform plan note
+        if: always()
+        run: |
+          {
+            echo "## Terraform Plan Artifact"
+            echo "- Environment: dev"
+            echo "- dev is usually destroyed; an all-create plan is expected and is not treated as failure."
+            echo "- Binary plan files are not uploaded."
+            echo "- Text plan output is uploaded as artifact with 3-day retention: terraform-plan-dev-${{ github.event.pull_request.number }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 目的（推奨）

terraform/** を変更するPRで `terraform plan` を自動実行し、dev環境の再構築差分を artifact として確認できるようにする。

## 変更内容（推奨）

- `.github/workflows/pr-check.yml` に Terraform 変更検知 job を追加
- `terraform/**` 変更時かつ同一リポジトリPRの場合だけ、dev環境の `terraform plan` job を実行
- plan前に `client/dist` を用意するため frontend build を実行
- `terraform plan -refresh=true -lock=false -detailed-exitcode` の出力を `terraform-plan.txt` に保存し、artifact として3日間保持
- plan binary は保存せず、Job Summary には artifact の短い案内だけを書く

## 影響範囲（推奨）

- **対象**: PR向けGitHub Actions、Terraform dev plan のレビュー補助
- **非対象**: `terraform apply`、deploy/destroy workflow、Job Summaryの詳細表示、danger signal判定、required status check化

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:ci-cd`, `area:infra`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。PR check workflow の追加のみで、既存AWSリソースは変更しない。
**コスト根拠**: なし。PR時のGitHub Actions実行時間は増えるが、AWSリソース作成は行わない。
**リスク根拠**: `.github/workflows/**` の変更であり、GitHub ActionsからAWS OIDC Roleをassumeするplan経路に関わるため `risk:medium`。fork PRではplan jobを実行しない条件を入れている。

</details>

## 可観測性/検証 *条件付き*

- `python3` による `.github/workflows/pr-check.yml` のYAML parse確認
- `git diff --check`
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform/foundation init -backend=false`
- `terraform -chdir=terraform/foundation validate`
- `terraform -chdir=terraform/environments/dev init -backend=false`
- `terraform -chdir=terraform/environments/dev validate`

AWS認証を使う実際の `terraform plan` はローカルでは実行していない。PR上のGitHub Actionsで確認する。
`terraform init -backend=false` では既存の `dynamodb_table` deprecated warning が出るが、今回変更とは別の既存backend設定由来。

## ロールバック *条件付き*

このPRは厳密運用PRとして扱う。

戻す場合は、このPRの `.github/workflows/pr-check.yml` 変更をrevertし、追加した `terraform-plan-changes` / `terraform-plan` job とトップレベルenvを削除する。AWSリソースやTerraform stateは変更していないため、GitHub Actions workflowのrevertだけで元に戻せる。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

このPRのGitHub Actionsで、terraform/** 変更時に `Terraform Plan Artifact` が動き、`terraform-plan-dev-<PR番号>` artifact が作成されることを確認する。

</details>

## メモ（レビューポイント）

- `pull_request_target` は使わず、fork PRではAWS Roleをassumeしない
- `terraform plan` の全文はActionsログに流さず、artifactに保存する
- #124 のdanger signal判定、#125 のJob Summary詳細表示、#128 のrequired status check化は後続Issueの範囲として残す


Closes #122
