### PR TITLE
ci: summarize terraform plan in job summary

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -297,13 +297,74 @@ jobs:
           if-no-files-found: warn
           retention-days: 3
 
-      - name: Write Terraform plan note
+      - name: Write Terraform plan summary
         if: always()
+        env:
+          PLAN_STATUS: ${{ steps.terraform_plan.outputs.plan_status }}
+          ARTIFACT_NAME: terraform-plan-dev-${{ github.event.pull_request.number }}
         run: |
+          set -e
+
+          plan_file="terraform/environments/dev/terraform-plan.txt"
+          exit_file="terraform/environments/dev/terraform-plan-exitcode.txt"
+          plan_exit="unknown"
+          add_count="unknown"
+          change_count="unknown"
+          destroy_count="unknown"
+          result_label="Not completed"
+          result_note="Terraform plan did not complete. Check the job logs and artifact for details."
+
+          if [ -f "$exit_file" ]; then
+            plan_exit="$(cat "$exit_file")"
+          fi
+
+          if [ -f "$plan_file" ]; then
+            plan_counts=$(sed -nE 's/^Plan: ([0-9]+) to add, ([0-9]+) to change, ([0-9]+) to destroy\..*/\1 \2 \3/p' "$plan_file" | tail -n 1)
+            if [ -n "$plan_counts" ]; then
+              set -- $plan_counts
+              add_count="$1"
+              change_count="$2"
+              destroy_count="$3"
+            elif grep -q '^No changes\.' "$plan_file"; then
+              add_count="0"
+              change_count="0"
+              destroy_count="0"
+            fi
+          fi
+
+          if [ "${PLAN_STATUS:-}" = "no_changes" ]; then
+            result_label="No changes"
+            result_note="Terraform reported no changes."
+          elif [ "${PLAN_STATUS:-}" = "changes" ]; then
+            result_label="Changes detected"
+            result_note="Review the plan artifact for full details."
+
+            if [ "$add_count" != "unknown" ] && [ "$change_count" = "0" ] && [ "$destroy_count" = "0" ]; then
+              result_note="All-create plan. This is expected for the normal destroyed dev environment and is not treated as a warning by itself."
+            fi
+          elif [ "${PLAN_STATUS:-}" = "failed" ]; then
+            result_label="Plan failed"
+            result_note="Check the job logs and uploaded plan artifact for the failure reason."
+          fi
+
           {
-            echo "## Terraform Plan Artifact"
+            echo "## Terraform Plan Summary"
+            echo
             echo "- Environment: dev"
             echo "- dev is usually destroyed; an all-create plan is expected and is not treated as failure."
+            echo "- Apply is not executed."
             echo "- Binary plan files are not uploaded."
-            echo "- Text plan output is uploaded as artifact with 3-day retention: terraform-plan-dev-${{ github.event.pull_request.number }}"
+            echo "- Text plan output artifact: \`$ARTIFACT_NAME\` (retention: 3 days)"
+            echo
+            echo "### Result"
+            echo
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| Status | \`$result_label\` |"
+            echo "| Terraform exit code | \`$plan_exit\` |"
+            echo "| Add | \`$add_count\` |"
+            echo "| Change | \`$change_count\` |"
+            echo "| Destroy | \`$destroy_count\` |"
+            echo
+            echo "$result_note"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 目的（推奨）

terraform plan の artifact を開く前に、PRチェックのJob Summaryで plan 結果の入口情報を把握できるようにする。

## 変更内容（推奨）

- `Terraform Plan Artifact` job の summary 出力を `Terraform Plan Summary` に変更
- `terraform-plan.txt` / `terraform-plan-exitcode.txt` から status、exit code、add/change/destroy 件数を表示
- `no changes` / `changes` / `failed` の表示分岐を追加
- dev環境は通常destroy済みであり、all-create plan はそれ自体では警告扱いしないことをsummaryに表示
- plan全文は引き続き artifact に保存し、PRコメント投稿やCI合否条件の変更は行わない

## 影響範囲（推奨）

- **対象**: `terraform/**` 変更PRで実行される Terraform plan job のJob Summary表示
- **非対象**: Terraform apply、plan artifact保存方式、danger signal抽出、PRコメント投稿、required status check設定

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:ci-cd`, `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。GitHub Actions のsummary表示のみを変更する。
**コスト根拠**: なし。追加のAWSリソース作成や実行job追加はない。
**リスク根拠**: `.github/workflows/**` の変更なので厳密運用として扱う。ただしCI合否条件やAWS権限、apply/destroyの挙動は変更しない。

</details>

## 可観測性/検証 *条件付き*

- `python3` による `.github/workflows/pr-check.yml` のYAML parse確認
- `bash -n` による summary 生成スクリプトの構文確認
- ダミー入力で `changes` / `no_changes` / `failed` のsummary生成確認
- `git diff --check`
- `terraform fmt -check -recursive`

このPR自体は `.github/workflows/**` のみの変更で `terraform/**` を変更していないため、`Terraform Plan Artifact` job は skipped が想定挙動。実際のJob Summary表示は後続の `terraform/**` 変更PRで確認する。

## ロールバック *条件付き*

このPRは `.github/workflows/**` 変更のため厳密運用PRとして扱う。

戻す場合は、このPRの `.github/workflows/pr-check.yml` 変更をrevertし、`Write Terraform plan summary` step を以前の簡易的な artifact 案内表示へ戻す。AWSリソース、Terraform state、plan artifact保存方式は変更していないため、workflowのrevertだけで元に戻せる。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

ローカルではsummary生成スクリプトを抽出し、以下の入力で表示分岐を確認した。

- `changes`: `Status = Changes detected`
- `no_changes`: `Status = No changes`
- `failed`: `Status = Plan failed`

</details>

## メモ（レビューポイント）

- plan全文はJob Summaryに出さず、artifactに残す
- all-create plan はdestroy済みdev運用では想定内として説明する
- #124 のdanger signal抽出はこのPRでは扱わない

Closes #125
