### PR TITLE
ci: harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   AWS_ACCOUNT_ID: "258632448142"
   AWS_REGION: "ap-northeast-1"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,16 +9,21 @@ on:
   #   branches: [main]
   # schedule:
   #   - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
 jobs:
   dependency-scan:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner (npm)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -34,6 +39,7 @@ jobs:
     name: Container Image Scan
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +54,7 @@ jobs:
           cache-to: type=gha,mode=max
           load: true
       - name: Run Trivy vulnerability scanner (Docker)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: "nestjs-hannibal-3:${{ github.sha }}"
           format: "sarif"
@@ -77,6 +83,7 @@ jobs:
   summary:
     name: Security Scan Summary
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - dependency-scan
       - container-scan


### PR DESCRIPTION
## 目的（推奨）
GitHub Actions workflow の権限と外部 Action 参照を整理し、CI/CD workflow の安全性を引き締めます。

## 変更内容（推奨）
- `pr-check.yml` に top-level `permissions: contents: read` を明示しました。
- `security-scan.yml` に top-level / job-level の `permissions` を明示しました。
- `aquasecurity/trivy-action@master` を `aquasecurity/trivy-action@v0.36.0` に固定しました。
- 権限不要な summary job は `permissions: {}` にしました。

## 影響範囲（推奨）
- **対象**: `.github/workflows/pr-check.yml`, `.github/workflows/security-scan.yml`
- **非対象**: repo 設定の allowed actions 制限、SHA pinning required、全 Action の major version 更新、required status check 設定、AWS / Terraform / IAM リソース

## PRラベル（必須）
- **type**: `type:infra`
- **area**: `area:ci-cd`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。workflow YAML のみの変更です。
**コスト根拠**: なし。AWS リソースや GitHub 有料設定は変更しません。
**リスク根拠**: `.github/workflows/**` を変更するため厳密運用です。PR check / security scan の権限設定と外部 Action 参照に影響します。

</details>

## 可観測性/検証 *条件付き*
- `git diff --check`
- `rg '@master|aquasecurity/trivy-action|permissions:' .github/workflows/pr-check.yml .github/workflows/security-scan.yml`
- Python `yaml.safe_load` による YAML parse
- タブ混入チェック
- `actionlint` はローカル未インストールのため未実施

## ロールバック *条件付き*
この PR を revert します。

戻る内容は次の通りです。
- `pr-check.yml` の top-level `permissions: contents: read` を削除
- `security-scan.yml` の追加 `permissions` 明示を削除
- `aquasecurity/trivy-action@v0.36.0` を変更前の `@master` 参照へ戻す

変更対象は workflow YAML のみです。AWS リソース、Terraform state、GitHub repo 設定は変更していないため、追加のクラウド側ロールバックは不要です。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```text
git diff --check
=> passed

Python yaml.safe_load
=> .github/workflows/pr-check.yml: YAML OK
=> .github/workflows/security-scan.yml: YAML OK

actionlint
=> actionlint not installed
```

</details>

## メモ（レビューポイント）
- `@master` 排除と `permissions` 明示に絞った初回 hardening PR です。
- allowed actions 制限、SHA pinning required、全 Action の major version 更新は今回の対象外です。


Closes #131
