### PR TITLE
ci: add job summary to PR policy check and terraform check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -88,45 +88,78 @@ jobs:
             exit 1
           fi
 
+          # --- Collect check results ---
+          errors=()
+
+          type_label=$(echo "$labels_json" | jq -r '[.[] | select(startswith("type:"))] | join(", ")')
+          area_labels=$(echo "$labels_json" | jq -r '[.[] | select(startswith("area:"))] | join(", ")')
+          risk_label=$(echo "$labels_json" | jq -r '[.[] | select(startswith("risk:"))] | join(", ")')
+          cost_label=$(echo "$labels_json" | jq -r '[.[] | select(startswith("cost:"))] | join(", ")')
+
           if [ "$type_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one type:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
-            exit 1
+            errors+=("type:* ラベルがちょうど1つ必要です（現在: ${type_count}件）")
+            type_status="❌ ${type_count}件（ちょうど1つ必要）"
+          else
+            type_status="✅ \`${type_label}\`"
           fi
 
           if [ "$area_count" -lt 1 ]; then
-            echo "::error::PR must have at least one area:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
-            exit 1
+            errors+=("area:* ラベルが1つ以上必要です（現在: 0件）")
+            area_status="❌ 0件（1つ以上必要）"
+          else
+            area_status="✅ \`${area_labels}\`"
           fi
 
           if [ "$risk_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one risk:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
-            exit 1
+            errors+=("risk:* ラベルがちょうど1つ必要です（現在: ${risk_count}件）")
+            risk_status="❌ ${risk_count}件（ちょうど1つ必要）"
+          else
+            risk_status="✅ \`${risk_label}\`"
           fi
 
           if [ "$cost_count" -ne 1 ]; then
-            echo "::error::PR must have exactly one cost:* label. Use ./scripts/github/create-pr-with-labels.sh to create PRs with the required labels."
-            exit 1
+            errors+=("cost:* ラベルがちょうど1つ必要です（現在: ${cost_count}件）")
+            cost_status="❌ ${cost_count}件（ちょうど1つ必要）"
+          else
+            cost_status="✅ \`${cost_label}\`"
           fi
 
-          strict_by_paths=false
-
+          # Strict mode detection
           if [ "$strict_by_cost" = true ]; then
             strict_by_labels=true
           fi
 
           changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          strict_by_paths=false
           if printf '%s\n' "$changed_files" | grep -Eq '^(terraform/|\.github/workflows/|scripts/deployment/|scripts/validation/)'; then
             strict_by_paths=true
           fi
 
-          if printf '%s\n' "$PR_BODY" | grep -Eiq '(close[sd]?|fix(e[sd])?|refs?) #[0-9]+'; then
-            echo "Linked issue found."
-          else
-            echo "::error::PR body must include a linked issue, for example: Closes #123, Fixes #123, or Refs #123. ./scripts/github/create-pr-with-labels.sh appends Closes #<issue番号> automatically."
-            exit 1
+          is_strict=false
+          strict_reasons=()
+          if [ "$strict_by_labels" = true ] || [ "$strict_by_paths" = true ]; then
+            is_strict=true
+            risk_val=$(echo "$labels_json" | jq -r '.[] | select(. == "risk:medium" or . == "risk:high")' | head -1)
+            cost_val=$(echo "$labels_json" | jq -r '.[] | select(. == "cost:medium" or . == "cost:large")' | head -1)
+            [ -n "$risk_val" ] && strict_reasons+=("\`${risk_val}\` ラベル")
+            [ -n "$cost_val" ] && strict_reasons+=("\`${cost_val}\` ラベル")
+            printf '%s\n' "$changed_files" | grep -q '^terraform/'          && strict_reasons+=("\`terraform/**\` 変更")
+            printf '%s\n' "$changed_files" | grep -q '^\.github/workflows/' && strict_reasons+=("\`\.github/workflows/**\` 変更")
+            printf '%s\n' "$changed_files" | grep -q '^scripts/deployment/' && strict_reasons+=("\`scripts/deployment/**\` 変更")
+            printf '%s\n' "$changed_files" | grep -q '^scripts/validation/' && strict_reasons+=("\`scripts/validation/**\` 変更")
           fi
 
-          if [ "$strict_by_labels" = true ] || [ "$strict_by_paths" = true ]; then
+          # Issue link check
+          if printf '%s\n' "$PR_BODY" | grep -Eiq '(close[sd]?|fix(e[sd])?|refs?) #[0-9]+'; then
+            issue_status="✅ リンクあり"
+          else
+            errors+=("PR本文にIssueリンクが必要です（例: Closes #123）")
+            issue_status="❌ リンクなし（Closes #123 / Fixes #123 / Refs #123 が必要）"
+          fi
+
+          # Rollback check
+          rollback_status="— 軽運用PRのため不要"
+          if [ "$is_strict" = true ]; then
             rollback_content=$(printf '%s\n' "$PR_BODY" | awk '
               /^###[[:space:]]+ロールバック/ || /^##[[:space:]]+ロールバック/ { capture=1; next }
               capture && (/^###[[:space:]]+/ || /^##[[:space:]]+/) { capture=0 }
@@ -141,9 +174,72 @@ jobs:
               | tr -d '[:space:]')
 
             if [ -z "$rollback_compact" ] || printf '%s' "$rollback_compact" | grep -Eiq '^(なし|不要|no-op|noop|n/a|na)$'; then
-              echo "::error::Strict PRs must include a substantive rollback section."
-              exit 1
+              errors+=("厳密運用PRにはロールバック欄への記載が必要です")
+              rollback_status="❌ 未記載（厳密運用PRのため必須）"
+            else
+              rollback_status="✅ 記載あり（厳密運用）"
             fi
+          fi
+
+          # --- Write Job Summary ---
+          strict_reason_str=""
+          for r in "${strict_reasons[@]}"; do
+            if [ -n "$strict_reason_str" ]; then
+              strict_reason_str="${strict_reason_str}, ${r}"
+            else
+              strict_reason_str="$r"
+            fi
+          done
+
+          {
+            echo "## PR Policy Check"
+            echo ""
+            echo "### ラベル"
+            echo ""
+            echo "| カテゴリ | 結果 |"
+            echo "|---|---|"
+            echo "| \`type:*\` | $type_status |"
+            echo "| \`area:*\` | $area_status |"
+            echo "| \`risk:*\` | $risk_status |"
+            echo "| \`cost:*\` | $cost_status |"
+            echo ""
+            echo "### Issue リンク"
+            echo ""
+            echo "$issue_status"
+            echo ""
+            echo "### 運用区分"
+            echo ""
+            if [ "$is_strict" = true ]; then
+              echo "**厳密運用**（理由: ${strict_reason_str}）"
+            else
+              echo "軽運用"
+            fi
+            echo ""
+            echo "### ロールバック"
+            echo ""
+            echo "$rollback_status"
+            echo ""
+            echo "---"
+            echo ""
+            if [ ${#errors[@]} -eq 0 ]; then
+              echo "✅ 全チェック通過"
+            else
+              echo "❌ ${#errors[@]}件の問題があります"
+              echo ""
+              for err in "${errors[@]}"; do
+                echo "- $err"
+              done
+              echo ""
+              echo "修正方法: \`./scripts/github/create-pr-with-labels.sh\` を使ってPRを作成してください"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # --- Exit with error if any checks failed ---
+          if [ ${#errors[@]} -gt 0 ]; then
+            for err in "${errors[@]}"; do
+              echo "::error::$err"
+            done
+            exit 1
           fi
 
   backend-check:
@@ -204,6 +300,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Terraform Format Check
+        id: fmt_check
         run: terraform fmt -check -recursive
 
       - name: Terraform Init (dev)
@@ -211,8 +308,45 @@ jobs:
         run: terraform init -backend=false
 
       - name: Terraform Validate (dev)
+        id: validate_dev
         working-directory: ./terraform/environments/dev
         run: terraform validate
+
+      - name: Write Terraform Check Summary
+        if: always()
+        env:
+          FMT_OUTCOME: ${{ steps.fmt_check.outcome }}
+          VALIDATE_OUTCOME: ${{ steps.validate_dev.outcome }}
+        run: |
+          {
+            echo "## Terraform Format & Validate"
+            echo ""
+            echo "| チェック | 結果 |"
+            echo "|---|---|"
+
+            if [ "$FMT_OUTCOME" = "success" ]; then
+              echo "| \`terraform fmt -check -recursive\` | ✅ 差分なし |"
+            elif [ "$FMT_OUTCOME" = "failure" ]; then
+              echo "| \`terraform fmt -check -recursive\` | ❌ 差分あり |"
+            fi
+
+            if [ "$VALIDATE_OUTCOME" = "success" ]; then
+              echo "| \`terraform validate\` | ✅ 問題なし |"
+            elif [ "$VALIDATE_OUTCOME" = "failure" ]; then
+              echo "| \`terraform validate\` | ❌ エラーあり |"
+            elif [ "$VALIDATE_OUTCOME" = "skipped" ]; then
+              echo "| \`terraform validate\` | — スキップ |"
+            fi
+
+            if [ "$FMT_OUTCOME" = "failure" ]; then
+              echo ""
+              echo "以下を実行してフォーマットを修正してください:"
+              echo ""
+              echo '```bash'
+              echo "terraform fmt -recursive"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   terraform-plan-changes:
     name: Terraform Plan Change Detection


### PR DESCRIPTION
## 目的

PR Policy Check と Terraform Format & Validate の失敗理由を Job Summary に表示し、修正方法を見つけやすくする。

## 変更内容

**`pr-policy-check` job**:
- ラベルチェック・Issueリンクチェック・rollbackチェックの結果を収集してから Summary に書き、最後に exit する構造に変更
- Summary にラベル診断表・Issueリンク状態・運用区分（厳密/軽）とその判定理由・rollback状態を表示
- 問題がある場合は件数と内容・修正方法を表示

**`terraform-check` job**:
- `Terraform Format Check` に `id: fmt_check` を追加
- `Terraform Validate (dev)` に `id: validate_dev` を追加
- `if: always()` の Summary ステップを追加。fmt 失敗時は `terraform fmt -recursive` の修正コマンドを案内

## 影響範囲

- **対象**: `.github/workflows/pr-check.yml` のみ
- **非対象**: branch protection / 合否ロジック / 権限設定

## ロールバック

このコミットを revert するだけ。branch protection・AWS・他 job への影響なし。合否ロジックは変えていないため、revert で即座に元の動作に戻る。


Closes #123
