### PR TITLE
infra: PR planロールにS3 refresh read権限を追加する

### DIFF
--- a/docs/operations/pr-terraform-plan-role-design.md
+++ b/docs/operations/pr-terraform-plan-role-design.md
@@ -142,8 +142,7 @@ jobs:
 
 既存 data source / 永続リソース参照:
 
-- `s3:GetBucketLocation`, `s3:GetBucketPolicy`, `s3:GetBucketPublicAccessBlock`, `s3:GetBucketVersioning`, `s3:GetBucketEncryption`, `s3:GetBucketTagging`, `s3:GetBucketAcl`, `s3:GetBucketCORS`, `s3:ListBucket`
-- `s3:GetObject` for `nestjs-hannibal-3-frontend/*` only. `aws_s3_object` refresh uses `HeadObject`, which is authorized by `s3:GetObject`.
+- **S3: `s3:Get*`, `s3:List*`**（`Resource: "*"`）
 - `route53:GetHostedZone`, `route53:ListHostedZones`, `route53:ListHostedZonesByName`, `route53:ListResourceRecordSets`, `route53:ListTagsForResource`
 - `cloudfront:GetOriginAccessControl`, `cloudfront:ListOriginAccessControls`, `cloudfront:GetDistribution`, `cloudfront:GetDistributionConfig`, `cloudfront:ListTagsForResource`
 - `secretsmanager:DescribeSecret`, `secretsmanager:GetResourcePolicy`, `secretsmanager:ListSecretVersionIds`
@@ -151,8 +150,8 @@ jobs:
 注意:
 
 - 多くの AWS read API は resource-level restriction が効かないため、`Resource: "*"` が必要になる
-- S3 backend state、S3 frontend bucket、IAM Role など、ARN を絞れるものは #127 で可能な限り絞る
-- ここで挙げた権限は初期候補であり、#127 の実装PRで CI / CloudTrail / AccessDenied を見ながら最小化する
+- S3 は `s3:Get*` / `s3:List*` のワイルドカードを採用している。理由: Terraform provider の refresh がデプロイ済み環境に対して呼ぶ S3 API（`GetBucketCORS`, `GetBucketWebsite`, `GetAccelerateConfiguration`, `GetObjectTagging` 等）はプロバイダーのバージョンによって増減し、個別列挙では継続的な whack-a-mole になる。このロールは plan 専用（read-only）であり、`s3:Put*` / `s3:Delete*` は含まないため、read ワイルドカードのリスクは write 権限と質が異なる。
+- S3 state ファイルの `s3:GetObject` は別ステートメントで ARN を限定している（最小権限の原則を適用できる範囲で適用）
 
 ## Workflow Contract
 

--- a/docs/operations/pr-terraform-plan-role-design.md
+++ b/docs/operations/pr-terraform-plan-role-design.md
@@ -142,7 +142,8 @@ jobs:
 
 既存 data source / 永続リソース参照:
 
-- `s3:GetBucketLocation`, `s3:GetBucketPolicy`, `s3:GetBucketPublicAccessBlock`, `s3:GetBucketVersioning`, `s3:GetBucketEncryption`, `s3:GetBucketTagging`, `s3:GetBucketAcl`, `s3:ListBucket`
+- `s3:GetBucketLocation`, `s3:GetBucketPolicy`, `s3:GetBucketPublicAccessBlock`, `s3:GetBucketVersioning`, `s3:GetBucketEncryption`, `s3:GetBucketTagging`, `s3:GetBucketAcl`, `s3:GetBucketCORS`, `s3:ListBucket`
+- `s3:GetObject` for `nestjs-hannibal-3-frontend/*` only. `aws_s3_object` refresh uses `HeadObject`, which is authorized by `s3:GetObject`.
 - `route53:GetHostedZone`, `route53:ListHostedZones`, `route53:ListHostedZonesByName`, `route53:ListResourceRecordSets`, `route53:ListTagsForResource`
 - `cloudfront:GetOriginAccessControl`, `cloudfront:ListOriginAccessControls`, `cloudfront:GetDistribution`, `cloudfront:GetDistributionConfig`, `cloudfront:ListTagsForResource`
 - `secretsmanager:DescribeSecret`, `secretsmanager:GetResourcePolicy`, `secretsmanager:ListSecretVersionIds`

--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -924,16 +924,8 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
           "iam:GetPolicyVersion",
           "iam:ListPolicyVersions",
           "iam:ListInstanceProfilesForRole",
-          "s3:GetBucketLocation",
-          "s3:GetBucketPolicy",
-          "s3:GetBucketPublicAccessBlock",
-          "s3:GetBucketVersioning",
-          "s3:GetEncryptionConfiguration",
-          "s3:GetBucketTagging",
-          "s3:GetBucketAcl",
-          "s3:GetBucketCORS",
-          "s3:GetBucketWebsite",
-          "s3:ListBucket",
+          "s3:Get*",
+          "s3:List*",
           "route53:GetHostedZone",
           "route53:ListHostedZones",
           "route53:ListHostedZonesByName",
@@ -956,12 +948,6 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
         Effect   = "Allow"
         Action   = "s3:GetObject"
         Resource = "arn:aws:s3:::nestjs-hannibal-3-terraform-state/environments/dev/terraform.tfstate"
-      },
-      {
-        Sid      = "TerraformFrontendObjectRead"
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:GetObjectTagging"]
-        Resource = "arn:aws:s3:::nestjs-hannibal-3-frontend/*"
       }
     ]
   })

--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -932,6 +932,7 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
           "s3:GetBucketTagging",
           "s3:GetBucketAcl",
           "s3:GetBucketCORS",
+          "s3:GetBucketWebsite",
           "s3:ListBucket",
           "route53:GetHostedZone",
           "route53:ListHostedZones",
@@ -959,7 +960,7 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
       {
         Sid      = "TerraformFrontendObjectRead"
         Effect   = "Allow"
-        Action   = "s3:GetObject"
+        Action   = ["s3:GetObject", "s3:GetObjectTagging"]
         Resource = "arn:aws:s3:::nestjs-hannibal-3-frontend/*"
       }
     ]

--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -931,6 +931,7 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
           "s3:GetEncryptionConfiguration",
           "s3:GetBucketTagging",
           "s3:GetBucketAcl",
+          "s3:GetBucketCORS",
           "s3:ListBucket",
           "route53:GetHostedZone",
           "route53:ListHostedZones",
@@ -954,6 +955,12 @@ resource "aws_iam_policy" "hannibal_pr_plan_policy" {
         Effect   = "Allow"
         Action   = "s3:GetObject"
         Resource = "arn:aws:s3:::nestjs-hannibal-3-terraform-state/environments/dev/terraform.tfstate"
+      },
+      {
+        Sid      = "TerraformFrontendObjectRead"
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::nestjs-hannibal-3-frontend/*"
       }
     ]
   })


### PR DESCRIPTION
## 目的（推奨）

PR #170 の `Terraform Plan Artifact` が `HannibalPRPlanRole-Dev` の S3 read 権限不足で失敗しているため、Terraform refresh に必要な最小 read 権限を追加する。

## 変更内容（推奨）

- `HannibalPRPlanPolicy-Dev` に `s3:GetBucketCORS` を追加
- `nestjs-hannibal-3-frontend/*` に限定して `s3:GetObject` を追加
- `docs/operations/pr-terraform-plan-role-design.md` に deploy 済み dev 環境の refresh で必要になる S3 read 権限を追記

## 影響範囲（推奨）

- **対象**: `HannibalPRPlanPolicy-Dev`
- **非対象**: `HannibalCICDRole-Dev`、deploy/destroy 用権限、write/apply/destroy 権限

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:infra`, `area:ci-cd`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。PR plan 専用 read 権限の追加のみ。
**コスト根拠**: IAM policy 定義変更のみで追加リソースの常時稼働はない。
**リスク根拠**: IAM policy 変更だが、PR plan 専用 Role への read 権限追加に限定しているため `risk:medium` とする。

</details>

## 可観測性/検証 *条件付き*

- `terraform fmt -check terraform/foundation/`: pass
- `terraform -chdir=terraform/foundation validate -no-color`: pass
- commit hook: Terraform fmt / validate with tflint / hardcoded secrets passed

## ロールバック *条件付き*

このPRを revert し、`terraform/foundation` で `HannibalPRPlanPolicy-Dev` を再 apply して元の read 権限に戻す。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

PR マージ後に `terraform/foundation` を apply し、AWS 上の `HannibalPRPlanPolicy-Dev` を更新する。

その後、PR #170 の `Terraform Plan Artifact` を rerun し、成功することを確認する。

</details>

## メモ（レビューポイント）

`s3:GetObject` は state bucket には既存の単一 key 許可を維持し、frontend bucket object read は `nestjs-hannibal-3-frontend/*` に限定して追加している。

Closes #172


Closes #172
