### PR TITLE
infra: DeveloperRoleにfoundation apply用権限を追加する

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -149,12 +149,40 @@ resource "aws_iam_policy" "hannibal_developer_policy" {
         Resource = "*"
       },
       {
-        # IAM権限 (フル操作)
+        # IAM権限 (開発・Terraform foundation applyに必要な範囲)
         Effect = "Allow"
         Action = [
-          "iam:*"
+          "iam:Get*",
+          "iam:List*",
+          "iam:CreateRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:DeleteRole",
+          "iam:PassRole",
+          "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+          "iam:SetDefaultPolicyVersion",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy"
         ]
         Resource = "*"
+      },
+      {
+        # Terraform state lock table (foundation backend)
+        Effect = "Allow"
+        Action = [
+          "dynamodb:DescribeTable",
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem"
+        ]
+        Resource = "arn:aws:dynamodb:ap-northeast-1:${var.aws_account_id}:table/terraform-state-lock"
       }
     ]
   })


### PR DESCRIPTION
## 目的（推奨）

`HannibalDeveloperRole-Dev` で `terraform/foundation apply` を正規手順で実行できるよう、IAM managed policy 更新権限と Terraform state lock 用 DynamoDB 権限を追加する。

## 変更内容（推奨）

- `HannibalDeveloperPolicy-Dev` の IAM 権限定義を実AWS上の明示 action に寄せる
- IAM managed policy version 更新用の権限を追加
  - `iam:CreatePolicyVersion`
  - `iam:DeletePolicyVersion`
  - `iam:SetDefaultPolicyVersion`
- foundation backend の state lock table に対する最小 DynamoDB 権限を追加
  - `dynamodb:DescribeTable`
  - `dynamodb:GetItem`
  - `dynamodb:PutItem`
  - `dynamodb:DeleteItem`

## 影響範囲（推奨）

- **対象**: `HannibalDeveloperPolicy-Dev`
- **非対象**: `HannibalCICDRole-Dev`、`HannibalPRPlanRole-Dev`、deploy/destroy workflow

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:infra`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。DeveloperRole 用 IAM policy の権限追加のみ。
**コスト根拠**: 既存IAM policy変更のみで追加リソースの常時稼働はない。
**リスク根拠**: IAM policy 変更だが、対象は開発者用 Role で、追加権限は foundation apply に必要な policy version 更新と state lock table に限定しているため `risk:medium` とする。

</details>

## 可観測性/検証 *条件付き*

- `terraform fmt -check terraform/foundation/`: pass
- `terraform -chdir=terraform/foundation validate -no-color`: pass
- commit hook: Terraform fmt / validate with tflint / hardcoded secrets passed

## ロールバック *条件付き*

このPRを revert し、`terraform/foundation` で `HannibalDeveloperPolicy-Dev` を再 apply して元の権限へ戻す。

問題が apply 前に見つかった場合は、このPRをマージしない。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

PR マージ後に `main` の内容で `terraform/foundation` を apply し、AWS 上の `HannibalDeveloperPolicy-Dev` を更新する。

その後、`HannibalDeveloperRole-Dev` で `terraform/foundation apply` が `-lock=false` なしで state lock を取得できることを確認する。

</details>

## メモ（レビューポイント）

`iam:*` に戻さず、実AWS上の明示IAM actionをベースに不足分だけを追加している。

Closes #169


Closes #169
