### PR TITLE
fix: candidateポリシーにs3バージョン操作権限を追加してdestroy失敗を修正する

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -554,7 +554,7 @@ resource "aws_iam_policy" "hannibal_cicd_policy_candidate_storage" {
           "s3:GetBucketTagging", "s3:GetBucketVersioning", "s3:GetBucketWebsite",
           "s3:GetEncryptionConfiguration", "s3:GetLifecycleConfiguration",
           "s3:GetReplicationConfiguration", "s3:GetAccelerateConfiguration",
-          "s3:ListBucket", "s3:PutBucketPolicy", "s3:PutBucketPublicAccessBlock",
+          "s3:ListBucket", "s3:ListBucketVersions", "s3:PutBucketPolicy", "s3:PutBucketPublicAccessBlock",
           "s3:PutBucketTagging", "s3:PutBucketVersioning", "s3:PutEncryptionConfiguration",
         ]
         Resource = [
@@ -567,7 +567,7 @@ resource "aws_iam_policy" "hannibal_cicd_policy_candidate_storage" {
         Sid    = "S3Object"
         Effect = "Allow"
         Action = [
-          "s3:DeleteObject", "s3:DeleteObjectTagging", "s3:GetObject",
+          "s3:DeleteObject", "s3:DeleteObjectTagging", "s3:DeleteObjectVersion", "s3:GetObject",
           "s3:GetObjectTagging", "s3:PutObject", "s3:PutObjectTagging",
         ]
         Resource = [


### PR DESCRIPTION
## 目的（推奨）

`HannibalCICDRole-Dev` の候補ポリシー（candidate-storage）に `s3:ListBucketVersions` と `s3:DeleteObjectVersion` が不足しており、Versioning 有効バケットの `terraform destroy` 時に 403 AccessDenied が発生していた。両アクションを追加して destroy を通す。

## 変更内容（推奨）

`hannibal_cicd_policy_candidate_storage` の `S3FrontendAndArtifacts` に `s3:ListBucketVersions`、`S3Object` に `s3:DeleteObjectVersion` を追加。

## 影響範囲（推奨）

- **対象**: `HannibalCICDRole-Dev` の S3 権限（destroy 時のみ使用）
- **非対象**: deploy・plan・他ロール

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:infra`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**: IAM ポリシー変更・`terraform/foundation` 配下・destroy に関わる変更のため `risk:medium`。追加権限は最小限（versioning 用 2 アクション）で、deploy・plan には影響しない。

</details>

## 可観測性/検証

- `terraform/foundation` で `apply` 後、destroy ワークフローを再実行して成功することを確認
- 失敗した run ID: 25430827795（エラー: `s3:ListBucketVersions` 403）

## ロールバック

`git revert 776fae8` → `terraform/foundation apply` で 2 アクションを削除。destroy は一時的に動かなくなるが、deploy・plan には影響なし。

## リリース連携

- **リリースノート**: 不要

Closes #177


Closes #177
