### PR TITLE
infra: foundation dead codeをstate管理に移行しBudgetsコスト通知を実装する

### DIFF
--- a/terraform/foundation/billing.tf
+++ b/terraform/foundation/billing.tf
@@ -1,30 +1,35 @@
-# AWS Budgets for Cost Management
-# 5USD～200USDの範囲で5USD刻み
+# AWS Budgets - 月次コスト通知
+# 上限 $50・4閾値。deploy/destroy を都度手動実行するプロジェクト向けの設定。
 
-locals {
-  budget_amounts = [for i in range(1, 41) : i * 5]
-}
-
-resource "aws_budgets_budget" "monthly_cost_budgets" {
-  for_each = { for amount in local.budget_amounts : "aws-account-cost-${amount}usd" => amount }
-
-  name         = each.key
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = "aws-account-monthly-cost"
   budget_type  = "COST"
-  limit_amount = each.value
+  limit_amount = "50"
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  time_period_start = "2025-01-01_09:00"
-  time_period_end   = "2030-12-31_09:00"
+  time_period_start = "2026-05-01_00:00"
+  time_period_end   = "2030-12-31_00:00"
 
+  # 実績 $10 超過（20%）
   notification {
     comparison_operator        = "GREATER_THAN"
-    threshold                  = 100
+    threshold                  = 20
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
     subscriber_email_addresses = [var.alert_email]
   }
 
+  # 実績 $25 超過（50%）
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 50
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+
+  # 予測 $40 超過（80%予測）
   notification {
     comparison_operator        = "GREATER_THAN"
     threshold                  = 80
@@ -32,10 +37,18 @@ resource "aws_budgets_budget" "monthly_cost_budgets" {
     notification_type          = "FORECASTED"
     subscriber_email_addresses = [var.alert_email]
   }
+
+  # 実績 $50 超過（100%）
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
 }
 
-# Output budget names for reference
 output "budget_names" {
-  description = "List of created budget names"
-  value       = keys(aws_budgets_budget.monthly_cost_budgets)
+  description = "Monthly cost budget name"
+  value       = aws_budgets_budget.monthly_cost.name
 }


### PR DESCRIPTION
## 目的
`terraform/foundation` にコードはあるが state にない dead code リソースが 10 本残っており、`terraform plan` で意図しない差分が出続けていた。`terraform import` で state に取り込み、plan がクリーンになる状態にする。合わせて billing.tf の Budgets 設定を適切な内容に書き直して apply する。

## 変更内容
- `terraform import` で 10 リソースを state 管理に移行
  - IAM: OIDC provider・DeveloperRole・CICDRole・Developer attachment
  - Athena: workgroup・database・named query×4
- `billing.tf` を書き直し: 40個 for_each（$5〜$200） → $50 上限・4閾値の1予算に変更
  - 実績 $10（20%）/ 実績 $25（50%）/ 予測 $40（80%）/ 実績 $50（100%）
- `terraform apply` で Budgets を AWS に作成

## 影響範囲
- **対象**: `terraform/foundation` state・AWS Budgets
- **非対象**: アプリインフラ・deploy/destroy ワークフロー・他 Role

<details>
<summary>影響メモ</summary>

**リスク根拠**: `terraform import` は state 破壊リスクがあるため事前にバックアップを取得。import 後の plan で差分がないことを確認済み。

</details>

## 可観測性/検証
- `terraform state list` で 27 リソースが管理されていることを確認済み
- `aws budgets describe-budgets` で $50 上限の予算が作成されていることを確認済み
- `terraform plan`（`-target` なし）で意図しない差分が出ないことを確認済み

## ロールバック
import は state への登録のみで AWS リソースを変更しないため、state を apply 前のバックアップに戻すだけで復旧可能。

```bash
terraform -chdir=terraform/foundation state push /tmp/foundation-state-backup-20260509.json
```

## リリース連携
- **リリースノート**: 不要

Closes #185


Closes #185
