### PR TITLE
PR: infra: Foundation Boundaryを簡素化する

### DIFF
--- a/docs/operations/iam-management.md
+++ b/docs/operations/iam-management.md
@@ -88,6 +88,7 @@ aws sts assume-role --role-arn arn:aws:iam::258632448142:role/HannibalFoundation
 - **基盤IAMロール・ポリシー**: `terraform/foundation` で扱い、厳密運用で変更する
 - **Foundation Boundary 変更**: `HannibalFoundationRole-Dev` ではなく、bootstrap / admin / break-glass 権限で厳密運用として実行する
 - **日常開発Role**: `HannibalDeveloperRole-Dev` はアプリ運用に使い、`terraform/foundation` の apply には使わない
+- **Boundary命名規約**: Foundation Role が Hannibal 系 Role に設定できる Permission Boundary は `Hannibal*Boundary*` に限定する
 - **Developer Role 最小権限化**: 既存 Role / Policy を直接縮小せず、candidate Role / Policy / Boundary で検証してから本体へ反映する
 - **アプリケーションIAMロール・ポリシー**: `terraform/environments/dev` から作成・破棄される
 - **段階的権限縮小**: CloudTrailログ分析とPRレビューで継続的に行う
@@ -109,6 +110,8 @@ aws sts assume-role --role-arn arn:aws:iam::258632448142:role/HannibalFoundation
 - **CloudTrail分析**: 実際の使用権限を特定する
 - **Permission Boundary**: 最大権限の制限
 - **Boundaryの管理分離**: 日常 apply 用 Role が自分の Boundary を書き換えられないようにする
+- **Boundaryの命名制限**: `Hannibal*Boundary*` に一致する managed policy だけを Hannibal 系 Role の Boundary として使う
+- **Boundaryの粒度**: `HannibalFoundationBoundary-Dev` は詳細な実権限ではなく、foundation が扱うサービス範囲の上限だけを短く定義する。詳細な許可は `HannibalFoundationPolicy-Dev` 側で管理する
 - **段階的権限縮小**: 過去分析を起点に、現状確認と縮小を継続する
 
 ### 環境分離

--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -1222,11 +1222,95 @@ resource "aws_iam_role_policy_attachment" "hannibal_pr_plan_policy_attachment" {
 # 用の高権限操作はこのロールへ分離する。
 
 locals {
-  hannibal_foundation_approved_boundary_arns = [
-    "arn:aws:iam::${var.aws_account_id}:policy/HannibalCICDBoundary",
-    "arn:aws:iam::${var.aws_account_id}:policy/HannibalDeveloperBoundary-Dev-candidate",
-    "arn:aws:iam::${var.aws_account_id}:policy/HannibalPRPlanBoundary-Dev",
-    "arn:aws:iam::${var.aws_account_id}:policy/HannibalFoundationBoundary-Dev"
+  hannibal_foundation_approved_boundary_arn_pattern = "arn:aws:iam::${var.aws_account_id}:policy/Hannibal*Boundary*"
+
+  hannibal_foundation_boundary_statements = [
+    {
+      Sid    = "DenyFoundationBoundaryPolicyMutation"
+      Effect = "Deny"
+      Action = [
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:SetDefaultPolicyVersion"
+      ]
+      Resource = "arn:aws:iam::${var.aws_account_id}:policy/HannibalFoundationBoundary-Dev"
+    },
+    {
+      Sid      = "DenyRemovingHannibalRoleBoundaries"
+      Effect   = "Deny"
+      Action   = "iam:DeleteRolePermissionsBoundary"
+      Resource = "arn:aws:iam::${var.aws_account_id}:role/Hannibal*"
+    },
+    {
+      Sid    = "AllowIAMFoundationServices"
+      Effect = "Allow"
+      Action = [
+        "iam:AddClientIDToOpenIDConnectProvider",
+        "iam:AttachRolePolicy",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:CreatePolicy",
+        "iam:CreatePolicyVersion",
+        "iam:CreateRole",
+        "iam:DeleteOpenIDConnectProvider",
+        "iam:DeletePolicy",
+        "iam:DeletePolicyVersion",
+        "iam:DeleteRole",
+        "iam:DeleteRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:Get*",
+        "iam:List*",
+        "iam:PutRolePermissionsBoundary",
+        "iam:PutRolePolicy",
+        "iam:RemoveClientIDFromOpenIDConnectProvider",
+        "iam:SetDefaultPolicyVersion",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:UpdateOpenIDConnectProviderThumbprint",
+        "iam:UpdateRole"
+      ]
+      Resource = "*"
+    },
+    {
+      Sid    = "AllowFoundationS3StateAndAthenaResults"
+      Effect = "Allow"
+      Action = [
+        "s3:DeleteObject",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:PutObject"
+      ]
+      Resource = [
+        "arn:aws:s3:::nestjs-hannibal-3-terraform-state",
+        "arn:aws:s3:::nestjs-hannibal-3-terraform-state/*",
+        "arn:aws:s3:::nestjs-hannibal-3-athena-results",
+        "arn:aws:s3:::nestjs-hannibal-3-athena-results/*"
+      ]
+    },
+    {
+      Sid    = "AllowFoundationDynamoDBLock"
+      Effect = "Allow"
+      Action = [
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem"
+      ]
+      Resource = "arn:aws:dynamodb:ap-northeast-1:${var.aws_account_id}:table/terraform-state-lock"
+    },
+    {
+      Sid    = "AllowFoundationManagedServices"
+      Effect = "Allow"
+      Action = [
+        "athena:*",
+        "budgets:*",
+        "cloudtrail:*",
+        "glue:*",
+        "guardduty:*",
+        "sts:GetCallerIdentity"
+      ]
+      Resource = "*"
+    }
   ]
 
   hannibal_foundation_policy_statements = [
@@ -1269,8 +1353,8 @@ locals {
       ]
       Resource = "arn:aws:iam::${var.aws_account_id}:role/Hannibal*"
       Condition = {
-        ArnEquals = {
-          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arns
+        ArnLike = {
+          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arn_pattern
         }
       }
     },
@@ -1284,8 +1368,8 @@ locals {
       ]
       Resource = "arn:aws:iam::${var.aws_account_id}:role/Hannibal*"
       Condition = {
-        ArnEquals = {
-          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arns
+        ArnLike = {
+          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arn_pattern
         }
       }
     },
@@ -1298,8 +1382,8 @@ locals {
       ]
       Resource = "arn:aws:iam::${var.aws_account_id}:role/Hannibal*"
       Condition = {
-        ArnEquals = {
-          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arns
+        ArnLike = {
+          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arn_pattern
         }
       }
     },
@@ -1312,11 +1396,9 @@ locals {
       ]
       Resource = "arn:aws:iam::${var.aws_account_id}:role/Hannibal*"
       Condition = {
-        ArnEquals = {
-          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arns
-        }
         ArnLike = {
-          "iam:PolicyARN" = "arn:aws:iam::${var.aws_account_id}:policy/Hannibal*"
+          "iam:PermissionsBoundary" = local.hannibal_foundation_approved_boundary_arn_pattern
+          "iam:PolicyARN"           = "arn:aws:iam::${var.aws_account_id}:policy/Hannibal*"
         }
       }
     },
@@ -1510,7 +1592,7 @@ resource "aws_iam_policy" "hannibal_foundation_boundary" {
 
   policy = jsonencode({
     Version   = "2012-10-17"
-    Statement = local.hannibal_foundation_policy_statements
+    Statement = local.hannibal_foundation_boundary_statements
   })
 }
 


### PR DESCRIPTION
## 目的（推奨）
#164 の candidate Role 作成を通すため、Foundation 側の IAM policy 文字数超過を解消する。

## 変更内容（推奨）
- Permission Boundary 許可条件を個別列挙から `Hannibal*Boundary*` の命名規約に変更
- `HannibalFoundationBoundary-Dev` を詳細権限コピーではなく、短い service-scope の上限 Boundary に簡素化
- IAM運用ドキュメントに Boundary 命名規約と粒度方針を追記

## 影響範囲（推奨）
- **対象**: `terraform/foundation/iam.tf`, `docs/operations/iam-management.md`
- **非対象**: 既存 `HannibalDeveloperRole-Dev` の権限縮小本体、candidate 検証結果の本体反映

## PRラベル（必須）
- **type**: `type:infra`
- **area**: `area:infra`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**: IAM / Permission Boundary の変更であり、`terraform/foundation` の厳密運用対象。既存 Developer Role の権限縮小はまだ行わず、Foundation Role が設定できる Boundary を `Hannibal*Boundary*` に広げる。

</details>

## 可観測性/検証 *条件付き*
- `terraform -chdir=terraform/foundation fmt -check`
- `terraform -chdir=terraform/foundation validate`
- `git diff --check`
- `terraform -chdir=terraform/foundation plan -var="aws_account_id=258632448142" -var="alert_email=komurayoshitodesu@gmail.com"`
- policy JSON length: Foundation Boundary `1854`, Foundation Policy `5564`, Developer candidate `5294`

## ロールバック *条件付き*
この PR のコミットを revert し、`terraform/foundation` を再 plan / apply して `HannibalFoundationPolicy-Dev` と `HannibalFoundationBoundary-Dev` を変更前の定義へ戻す。Foundation Boundary 自体の変更は Foundation Role ではなく bootstrap / admin / break-glass 権限で実行する。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- pre-commit: Terraform fmt / validate / hardcoded secrets check passed
- Terraform plan: `2 to add, 2 to change, 0 to destroy`

</details>

## メモ（レビューポイント）
- `Hannibal*Boundary*` の命名規約で candidate Boundary 追加時の policy 文字数増加を抑える
- Foundation Boundary は詳細実権限ではなく最大サービス範囲として短く保つ

Refs #164