### PR TITLE
docs: deploy検証結果をcandidate検証記録に追記する

### DIFF
--- a/docs/operations/iam-management.md
+++ b/docs/operations/iam-management.md
@@ -220,14 +220,21 @@ PR terraform plan 用のTrust Policyは [pr-terraform-plan-role-design.md](./pr-
 | foundation state `s3:GetObject` | explicitDeny ✓ | policy の Deny ステートメントが機能している |
 | IAM 危険操作（CreateRole / DeleteRole / Attach / Put 等） | all implicitDeny ✓ | |
 
-**未検証（dev deploy が必要）**:
-- ECS exec
-- Secrets Manager `GetSecretValue`
-- ECS service / task 実操作
-- RDS managed secret 参照
+**dev deploy あり検証結果（2026-05-09）**:
+
+| テスト | 結果 | 備考 |
+|---|---|---|
+| ECS exec（IAM simulation） | allowed ✓ | ローカルに Session Manager Plugin なし。IAM 権限は確認済み |
+| CloudWatch Logs `get-log-events` | OK ✓ | `/ecs/nestjs-hannibal-3-api-task` を実読み取り |
+| Secrets Manager `GetSecretValue`（RDS managed secret） | OK ✓ | `rds!db-*` prefix のシークレットを取得確認 |
+| `terraform/environments/dev plan -lock=false` | OK ✓ | deploy 後の state 読み取り成功 |
+| foundation state `s3:GetObject` | explicitDeny ✓ | |
+| `HannibalFoundationRole-Dev` assume（特権昇格テスト） | AccessDenied ✓ | |
 
 **既知の制限**:
 `terraform/environments/dev` の backend は `use_lockfile = true` と `dynamodb_table` を並用中（#189 待ち移行期間）。candidate policy は DynamoDB 権限を持たないため、`-lock=false` での plan が必要。#189 で DynamoDB が削除されれば S3 lockfile 単独になり、lock あり plan が通る。
+
+**次のステップ**: 全検証完了。後続 PR で `HannibalDeveloperPolicy-Dev` / Developer Role Boundary へ反映し、candidate リソースを削除する。
 
 ### 定期メンテナンス
 - **月次権限レビュー**: 使用されていない権限の特定


### PR DESCRIPTION
## 変更の概要

#164 の candidate role 検証（dev deploy あり）の結果を `docs/operations/iam-management.md` に追記する。

## 変更内容

- deploy あり検証結果テーブルを追加（6テスト全通過）
  - ECS exec: IAM simulation で allowed 確認
  - CloudWatch Logs: 実ログ取得 OK
  - Secrets Manager: RDS managed secret 取得 OK
  - terraform/environments/dev plan: state 読み取り OK
  - foundation state deny: explicitDeny 確認
  - HannibalFoundationRole-Dev assume: AccessDenied 確認（特権昇格防止）
- 「次のステップ」を追記（本体 Policy/Boundary への反映と candidate 削除）
- deploy なし検証の「未検証」セクションを削除（全項目検証済み）

## 影響範囲

- ドキュメントのみ。インフラ・IAM 実リソースへの変更なし

## 運用判定

軽運用（docs のみ）

## ロールバック

不要（ドキュメントのみ）

Refs #164