### PR TITLE
fix: HannibalDeveloperPolicy-DevのdescriptionをForceReplace回避のため維持する

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role" "hannibal_cicd_role" {
 # #164 で wildcard から action 列挙に最小権限化済み。statements は local.hannibal_developer_policy_statements で管理。
 resource "aws_iam_policy" "hannibal_developer_policy" {
   name        = "HannibalDeveloperPolicy-Dev"
-  description = "Least-privilege permissions for daily developer operations: ECS exec / logs / ECR push / Secrets / dev Terraform plan"
+  description = "Integrated development permissions - ECS/ECR/RDS/CloudWatch operations, limited Terraform execution"
 
   policy = jsonencode({
     Version   = "2012-10-17"


### PR DESCRIPTION
## 変更の概要

`aws_iam_policy` の `description` を変更すると `ForceNew` が発動し delete+create になる。Foundation Boundary 条件（role が `Hannibal*Boundary*` を持つこと）を満たせず `DetachRolePolicy` が AccessDenied になるため、description を元の値に戻す。

policy の内容（最小権限化）は PR #195 の apply 済みで AWS 上では正しい状態。この PR は Terraform state と config を一致させるための修正。

## 変更内容

- `HannibalDeveloperPolicy-Dev` の `description` を元の値に戻す（ForceNew 回避）

## 影響範囲

- Terraform config のみ。AWS リソースは apply 済みのため変更なし

## 運用判定

厳密運用（terraform/foundation 変更）

## ロールバック

不要（apply 済みの内容と一致させるだけ）

Refs #164