### PR TITLE
docs: aws_iam_policy ForceNewとFoundation Boundary条件の注意点を追記する

### DIFF
--- a/docs/operations/iam-management.md
+++ b/docs/operations/iam-management.md
@@ -196,6 +196,33 @@ PR terraform plan 用のTrust Policyは [pr-terraform-plan-role-design.md](./pr-
 3. **段階的削除**: テスト環境での検証後に本番適用
 4. **継続監視**: 削除後の動作確認
 
+### terraform/foundation apply の注意点
+
+#### `aws_iam_policy` の `description` は ForceNew
+
+Terraform の `aws_iam_policy` で `description` を変更すると、リソースが destroy → create（置き換え）になる。置き換えの際、Terraform はまず既存ポリシーを Role から detach しようとする。
+
+Foundation Policy の `DetachRolePolicy` 文には次の条件が付いている:
+
+```
+Condition:
+  ArnLike:
+    iam:PermissionsBoundary: "arn:aws:iam::...:policy/Hannibal*Boundary*"
+```
+
+これは「detach 対象の Role がすでに `Hannibal*Boundary*` の Boundary を持っているときだけ許可」という意味。Boundary を持たない Role（例: 新しく Boundary を付ける対象）への detach は AccessDenied になる。
+
+**結論**: `aws_iam_policy` の `description` は変更しない。policy 内容だけを変えれば in-place update（新バージョン作成）になり、detach が不要になる。
+
+#### Boundary を持たない Role への最初の apply
+
+Boundary がない Role に対して「Boundary を付与 + ポリシーを置き換え」を同一 apply で実行しようとすると上記で詰まる。安全な順序:
+
+1. Boundary 付与のみを apply する（`-target=aws_iam_role.*`）
+2. 次の apply でポリシー操作を実施する
+
+または policy の description を変えず in-place update にとどめれば 1 回の apply で通る。
+
 ### Developer Role candidate 検証プロセス
 1. bootstrap / admin / break-glass 権限で `terraform/foundation` を apply し、`HannibalDeveloperRole-Dev-candidate` / `HannibalDeveloperPolicy-Dev-candidate` / `HannibalDeveloperBoundary-Dev-candidate` を作成する
 2. `hannibal` IAM User の `AssumeDevRole` が Role ARN を明示している場合、検証期間中だけ candidate Role ARN を追加する


### PR DESCRIPTION
## 変更の概要

`terraform/foundation` apply 中に発生した非自明な制約（#164 対応中に踏んだ）を `docs/operations/iam-management.md` に記録する。

## 変更内容

「terraform/foundation apply の注意点」セクションを追加:

1. **`aws_iam_policy` の `description` は ForceNew**
   - description を変えると destroy + create になり、detach が必要になる
   - Foundation Policy の `DetachRolePolicy` 条件（role が `Hannibal*Boundary*` を持つこと）を満たせず AccessDenied になる
   - 対策: description は変えない（policy 内容だけ変えれば in-place update）

2. **Boundary を持たない Role への最初の apply**
   - 「Boundary 付与 + ポリシー置き換え」を同時にやると詰まる
   - 安全な順序: Boundary 付与 → ポリシー操作 の 2 step、または description を変えず in-place update

## 影響範囲

ドキュメントのみ

## 運用判定

軽運用

## ロールバック

不要

Refs #164