### PR TITLE
chore: terraform/foundation の変数を tfvars で管理し -var 指定を不要にする

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -70,7 +70,24 @@ terraform {
 `use_lockfile = true` により、Terraform は state key に対応する `.tflock` オブジェクトを S3 上で作成・削除してロックします。
 `dynamodb_table` は移行期間中のみ併用し、安定後に backend / IAM / docs から削除します。
 
-### 1-3. 初期化実行
+### 1-3. tfvars ファイル作成
+
+`terraform/foundation` は変数を `terraform.tfvars` で管理します（gitignore 済み）。
+`terraform.tfvars.example` を参考に実値を設定してください。
+
+```bash
+cp terraform/foundation/terraform.tfvars.example terraform/foundation/terraform.tfvars
+# エディタで aws_account_id と alert_email を実際の値に書き換える
+```
+
+`terraform.tfvars.example` の内容:
+
+```hcl
+aws_account_id = "123456789012"
+alert_email    = "your-email@example.com"
+```
+
+### 1-4. 初期化実行
 
 ```bash
 cd terraform/foundation
@@ -85,7 +102,7 @@ terraform init
 ```bash
 cd terraform/foundation
 terraform init -reconfigure
-terraform plan -var="aws_account_id=<AWS_ACCOUNT_ID>" -var="alert_email=<EMAIL>"
+terraform plan
 
 cd ../environments/dev
 terraform init -reconfigure
@@ -133,10 +150,12 @@ aws iam create-user --user-name hannibal
 
 ### 2-2. foundation Terraform apply
 
+事前に `terraform/foundation/terraform.tfvars` を作成済みであることを確認します（ステップ1-3参照）。
+
 ```bash
 cd terraform/foundation
 terraform init
-terraform apply -var="aws_account_id=<AWS_ACCOUNT_ID>" -var="alert_email=<EMAIL>"
+terraform apply
 ```
 
 **作成されるリソース:**

--- a/terraform/foundation/terraform.tfvars.example
+++ b/terraform/foundation/terraform.tfvars.example
@@ -1,0 +1,2 @@
+aws_account_id = "123456789012"
+alert_email    = "your-email@example.com"


### PR DESCRIPTION
## 目的

`terraform/foundation` に `terraform.tfvars` がなく、apply のたびに `-var="aws_account_id=..."` `-var="alert_email=..."` を手動指定する必要があった。指定漏れや誤値による Budgets 通知先の上書きリスクを解消する。

## 変更内容

- `terraform/foundation/terraform.tfvars.example` を新規追加（プレースホルダー値、コミット対象）
- `docs/setup/README.md` にステップ1-3「tfvars ファイル作成」を追加し、`-var` フラグ記述を2箇所削除
- `terraform/foundation/terraform.tfvars`（実値入り）はローカル作成・gitignore 済みのためコミット対象外

## 影響範囲

- **対象**: foundation apply 時の操作手順
- **非対象**: AWS リソース（変更なし）、`terraform/environments/dev/`

## 可観測性/検証

`terraform/foundation/terraform.tfvars` を作成した状態で `terraform -chdir=terraform/foundation validate` が通ることを確認済み（静的検証のみ、AWS 認証不要）。

## ロールバック

`terraform/foundation/terraform.tfvars` を削除し、apply 時に `-var` フラグを手動指定すれば元の運用に戻せる。AWS リソースへの影響なし。

## リリース連携

- **リリースノート**: 不要

## メモ（レビューポイント）

`.gitignore` に既存の `*.tfvars` パターンがあるため、`terraform.tfvars` は自動的に除外される。`terraform.tfvars.example` は `.example` サフィックスにより gitignore の対象外。

Closes #198