### PR TITLE
fix(iam): move CloudTrailLogsBucketPolicy to foundation all_policy_statements

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -1100,15 +1100,6 @@ locals {
       ]
       Resource = "*"
     },
-    {
-      Sid    = "CloudTrailLogsBucketPolicy"
-      Effect = "Allow"
-      Action = [
-        "s3:GetBucketPolicy",
-        "s3:PutBucketPolicy"
-      ]
-      Resource = "arn:aws:s3:::nestjs-hannibal-3-cloudtrail-logs"
-    }
   ]
 
   hannibal_foundation_all_policy_statements = [
@@ -1379,6 +1370,15 @@ locals {
       Effect   = "Allow"
       Action   = "sts:GetCallerIdentity"
       Resource = "*"
+    },
+    {
+      Sid    = "CloudTrailLogsBucketPolicy"
+      Effect = "Allow"
+      Action = [
+        "s3:GetBucketPolicy",
+        "s3:PutBucketPolicy"
+      ]
+      Resource = "arn:aws:s3:::nestjs-hannibal-3-cloudtrail-logs"
     }
   ]
 


### PR DESCRIPTION
## 目的
PR #207 で CloudTrailLogsBucketPolicy Sid を誤って hannibal_foundation_boundary_statements の末尾に配置してしまった。
正しくは hannibal_foundation_all_policy_statements に入れて foundation services identity policy に含める必要がある。

## 変更内容
- CloudTrailLogsBucketPolicy を boundary_statements から all_policy_statements の末尾に移動

## 影響範囲
- **対象**: HannibalFoundationServicesPolicy-Dev（Sid 追加）、HannibalFoundationBoundary-Dev（不要な Sid 削除）
- **非対象**: その他のリソース

## 可観測性/検証
terraform plan で 2 to add, 2 to change（trail + bucket policy / services policy + boundary）、0 to destroy を確認

## ロールバック
PR を revert して terraform/foundation apply

## リリース連携
- **リリースノート**: 不要

Refs #162