### PR TITLE
fix(athena): partition projection の month/day にゼロパディングを追加

### DIFF
--- a/terraform/foundation/athena.tf
+++ b/terraform/foundation/athena.tf
@@ -111,8 +111,10 @@ TBLPROPERTIES (
   'projection.year.range'='2025,2030',
   'projection.month.type'='integer',
   'projection.month.range'='01,12',
+  'projection.month.digits'='2',
   'projection.day.type'='integer',
   'projection.day.range'='01,31',
+  'projection.day.digits'='2',
   'storage.location.template'='s3://nestjs-hannibal-3-cloudtrail-logs/AWSLogs/${var.aws_account_id}/CloudTrail/ap-northeast-1/$${year}/$${month}/$${day}/'
 )
 EOF


### PR DESCRIPTION
## 目的

`projection.month.type=integer` がゼロパディングなしで値を生成するため、S3 の実パス（`05/`, `11/`）と一致させるには `month='05'` 形式が必要だった。`digits=2` を追加してゼロパディングを明示的に固定し、`month='5'` のようなクエリでも動作する状態にする。

## 変更内容

- `projection.month.digits=2` / `projection.day.digits=2` を CREATE TABLE named query の TBLPROPERTIES に追加

## 影響範囲

- **対象**: `terraform/foundation/athena.tf`（CREATE TABLE named query 1 本の replace）
- **非対象**: Athena workgroup / database、分析 named query 3 本、IAM、CloudTrail

## PRラベル

- **type**: `type:infra`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証

apply 後に既存テーブルを DROP し named query を再実行。`month='5'`（ゼロパディングなし）でクエリが実データを返すことを確認する。

```sql
SELECT COUNT(*) FROM hannibal_cloudtrail_db.cloudtrail_logs_partitioned
WHERE year='2026' AND month='5'
```

## ロールバック

軽運用のため省略。named query 1 本の replace のみ。

## リリース連携

- **リリースノート**: 不要

## メモ（レビューポイント）

#210 のテスト中に発見。`digits` プロパティを追加するだけで S3 実パスとの整合性が取れる。


Closes #212
