### PR TITLE
infra: public subnet の auto public IP を無効化

### DIFF
--- a/docs/architecture/security-design.md
+++ b/docs/architecture/security-design.md
@@ -37,6 +37,8 @@ Data Subnet (RDS) ← 完全非公開（Public IP なし）
 - DB層は完全非公開（インターネットアクセス不可）
 - ECSはNAT Gateway経由でDockerイメージ取得
 - ALBのみがインターネットからアクセス可能
+- Public Subnet は ALB / NAT Gateway 用に維持するが、サブネット内のリソースへ Public IP を自動付与しない
+- NAT Gateway は明示的に割り当てた Elastic IP を使うため、Public IP 自動付与の無効化による影響はない
 
 ### セキュリティグループ
 ```hcl

--- a/docs/architecture/terraform-modules.md
+++ b/docs/architecture/terraform-modules.md
@@ -66,6 +66,7 @@ module "vpc" {
 
 **特徴:**
 - DB層は完全非公開（Public IPなし、インターネットアクセスなし）
+- Public Subnet は ALB / NAT Gateway 用に維持し、リソース起動時の Public IP 自動付与は無効化
 - NAT Gateway経由でECSからのアウトバウンド通信を実現
 - Route53でドメイン管理（hamilcar-hannibal.click）
 

--- a/terraform/modules/networking/vpc/main.tf
+++ b/terraform/modules/networking/vpc/main.tf
@@ -36,7 +36,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.main.id
   cidr_block              = each.value.cidr
   availability_zone       = each.value.az
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = {
     Name        = "${var.project_name}-public-${each.key}"


### PR DESCRIPTION
## 目的（推奨）
Trivy Config で検出された public subnet の Public IP 自動付与を無効化し、不要な外部公開リスクを下げる。

## 変更内容（推奨）
- `aws_subnet.public` の `map_public_ip_on_launch` を `false` に変更
- docs に public subnet 自体は ALB / NAT Gateway 用に維持し、自動 Public IP 付与のみ無効化する意図を追記
- docs に NAT Gateway は明示的な Elastic IP を使うため影響しないことを追記

## 影響範囲（推奨）
- **対象**: public subnet で新規起動されるリソースへの Public IP 自動付与
- **非対象**: ALB / NAT Gateway / ECS / RDS 構成

## PRラベル（必須）
- **type**: `type:infra`
- **area**: `area:infra`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。subnet 属性の変更であり、既存 ALB / NAT Gateway / ECS / RDS の配置は変更しない。
**コスト根拠**: なし。新規リソース追加や常時稼働リソースの増加はない。
**リスク根拠**: `terraform/**` 変更かつ `risk:medium` のため厳密運用。ALB は internet-facing 設定と public subnet 配置を維持し、NAT Gateway は明示的な EIP を使うため Public IP 自動付与には依存しない。

</details>

## 可観測性/検証 *条件付き*
- `npm run commitlint -- --from main --to HEAD --verbose`
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform/environments/dev validate`
- `trivy config --severity HIGH,CRITICAL --exit-code 0 --skip-dirs docs/worklogs --skip-dirs docs/llm-repo-bundle --skip-dirs client/dist .`
- Trivy Config で `terraform/modules/networking/vpc/main.tf` が `Misconfigurations: 0` であることを確認

## ロールバック *条件付き*
`terraform/modules/networking/vpc/main.tf` の `aws_subnet.public` で `map_public_ip_on_launch` を `true` に戻し、docs の追記を revert する。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```console
$ npm run commitlint -- --from main --to HEAD --verbose
✔ found 0 problems, 0 warnings

$ terraform fmt -check -recursive

$ terraform -chdir=terraform/environments/dev validate
Success! The configuration is valid.

$ trivy config --severity HIGH,CRITICAL --exit-code 0 --skip-dirs docs/worklogs --skip-dirs docs/llm-repo-bundle --skip-dirs client/dist .
terraform/modules/networking/vpc/main.tf: Misconfigurations: 0
```

</details>

## メモ（レビューポイント）
- public subnet は引き続き ALB / NAT Gateway 用に維持する
- 今回は public subnet 上の自動 Public IP 付与だけを無効化する


Closes #231
