### PR TITLE
docs: Trivy Config の public subnet 検出ステータスを更新

### DIFF
--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -85,7 +85,8 @@ trivy config \
 
 - `tflint --recursive --config "$(pwd)/.tflint.hcl"` は通過
 - `gitleaks git --no-banner --redact --config .gitleaks.toml` は no leaks
-- `trivy config` は Dockerfile の root user、CloudFormation 旧資産、WAF 無効化、HTTP ALB listener、public subnet、security group egress などを検出
+- `trivy config` は Dockerfile の root user、CloudFormation 旧資産、WAF 無効化、HTTP ALB listener、security group egress などを検出
+  - `public subnet` の `map_public_ip_on_launch = true` は Issue #231 / PR #242 で修正済み（2026-05-17）
 
 `trivy config` の検出結果は初期導入時点ではレビュー補助として扱います。
 コスト最適化やデモ用途で意図的に採用している設計も含まれるため、後続作業で accepted risk / 修正対象 / 除外対象を整理します。


### PR DESCRIPTION
## 目的（推奨）
Issue #231 / PR #242 で `map_public_ip_on_launch = true` を修正した内容を quality-gates.md に反映する。

## 変更内容（推奨）
- `docs/operations/quality-gates.md` の Trivy Config 初期検証メモで `public subnet` を検出一覧から削除し、修正済みの旨を注記

## 影響範囲（推奨）
- **対象**: `docs/operations/quality-gates.md`
- **非対象**: インフラ構成・CI 動作

## PRラベル（必須）
- **type**: `type:docs`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
No-op（適用外）

## ロールバック *条件付き*
該当なし（doc-only）

## リリース連携（推奨）
- **リリースノート**: 不要

Refs #231