### PR TITLE
infra: ALB直アクセスをCloudFront経由に制限する

### DIFF
--- a/docs/architecture/security-design.md
+++ b/docs/architecture/security-design.md
@@ -26,7 +26,7 @@ IaC security は `tfsec` を新規採用せず、Aqua Security の `Trivy Config
 ```
 Internet Gateway
     ↓
-Public Subnet (ALB) ← インターネット公開
+Public Subnet (ALB) ← CloudFront origin-facing traffic のみ許可
     ↓
 App Subnet (ECS) ← NAT Gateway経由でアウトバウンドのみ
     ↓
@@ -36,25 +36,23 @@ Data Subnet (RDS) ← 完全非公開（Public IP なし）
 **特徴:**
 - DB層は完全非公開（インターネットアクセス不可）
 - ECSはNAT Gateway経由でDockerイメージ取得
-- ALBのみがインターネットからアクセス可能
+- ALB は internet-facing のまま維持するが、CloudFront 経由の API origin 通信だけを通すように制限する
 - Public Subnet は ALB / NAT Gateway 用に維持するが、サブネット内のリソースへ Public IP を自動付与しない
 - NAT Gateway は明示的に割り当てた Elastic IP を使うため、Public IP 自動付与の無効化による影響はない
 
 ### セキュリティグループ
 ```hcl
 # ALB Security Group
+data "aws_ec2_managed_prefix_list" "cloudfront_origin_facing" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 resource "aws_security_group" "alb" {
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 80
+    to_port         = 8080
+    protocol        = "tcp"
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront_origin_facing.id]
   }
 }
 
@@ -78,6 +76,27 @@ resource "aws_security_group" "rds" {
   }
 }
 ```
+
+#### Public ALB 直アクセス制限
+
+CloudFront の API origin は `api.hamilcar-hannibal.click` を参照し、その DNS は Route53 alias で ALB に向いています。
+そのため `aws_lb.main.internal = true` を単純に採用すると、現在の CloudFront custom origin から ALB へ到達できなくなる可能性があります。
+internal ALB 化は CloudFront VPC origins を含む private origin 構成への移行として別途設計します。
+
+Issue #232 では、既存の CloudFront 経由公開を維持しながら ALB への直接アクセスを減らすため、次の二段制限を採用します。
+
+- Security Group は AWS managed prefix list `com.amazonaws.global.cloudfront.origin-facing` からの TCP `80-8080` のみ許可する
+- CloudFront の ALB origin に `X-Hannibal-Origin-Verify` custom header を追加する
+- ALB の 443 / 8080 listener rule は、上記 header の値が一致する場合のみ target group へ forward する
+- header が一致しないリクエストは fallback listener rule で `403 Access denied` を返す
+
+CloudFront managed prefix list の weight は 55 で、default security group rule quota に近い値です。
+80 / 443 / 8080 を個別 rule にすると quota を超える可能性が高いため、ALB listener 範囲として TCP `80-8080` を1本の rule にまとめます。
+未使用ポートは ALB listener が存在しないため application traffic にはなりません。
+
+origin verify header の値は Terraform の `random_password` で生成し、Git には保存しません。
+ただし値は Terraform state に保存されるため、state bucket と state 操作用 IAM のアクセス管理を前提にします。
+ローテーションする場合は `alb_origin_secret_rotation_version` を `v1` から `v2` などへ更新して `terraform apply` します。
 
 ## IAM設計
 

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -112,6 +112,20 @@ ALB から ECS target group への通信は HTTP のまま維持します。
 ECS task は private subnet にあり、ingress は ALB security group から container port への通信に限定しているため、これは外部公開面ではなく内部経路として扱います。
 今後 `trivy config` で HTTP listener / HTTP origin finding を確認する場合は、CloudFront origin の `https-only` と ALB 80 の redirect 専用化が崩れていないかを優先して見ます。
 
+### Public ALB 直アクセス制限の扱い
+
+Issue #232 で、ALB は internet-facing のまま維持しつつ、CloudFront 経由の API origin 通信だけを通す二段制限を追加しました。
+
+- ALB security group の ingress は `0.0.0.0/0` ではなく、AWS managed prefix list `com.amazonaws.global.cloudfront.origin-facing` からの TCP `80-8080` に限定する
+- CloudFront の ALB origin は `X-Hannibal-Origin-Verify` custom header を付ける
+- ALB の 443 / 8080 listener rule は header が一致する場合のみ forward し、header がないリクエストは `403` を返す
+
+`aws_lb.main.internal = true` は今回採用しません。
+現在の CloudFront custom origin は public DNS の `api.hamilcar-hannibal.click` を使うため、internal ALB 化は CloudFront VPC origins を含む private origin 構成への移行として別 Issue で検討します。
+
+CloudFront managed prefix list は weight 55 のため、80 / 443 / 8080 を個別 ingress rule にすると security group rule quota を超えやすくなります。
+そのため TCP `80-8080` を1本の rule にまとめ、HTTP 層では secret header による listener rule でさらに制限します。
+
 ### 導入時に実施した検証
 
 Issue #226 の実装時点で、ローカルで実行可能な範囲のチェックを実行しました。

--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -24,3 +24,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f5ce5af7e58f7b3a06b902efb953b64895e5c70c203fc9cdeeb75db240abba31",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/environments/dev/frontend.tf
+++ b/terraform/environments/dev/frontend.tf
@@ -2,7 +2,17 @@
 # Frontend モジュール統合設定
 
 locals {
-  api_domain_name = "api.${var.domain_name}"
+  api_domain_name               = "api.${var.domain_name}"
+  alb_origin_verify_header_name = "X-Hannibal-Origin-Verify"
+}
+
+resource "random_password" "alb_origin_verify_header" {
+  length  = 48
+  special = false
+
+  keepers = {
+    rotation_version = var.alb_origin_secret_rotation_version
+  }
 }
 
 # --- CDN Pillar: S3 Static Hosting ---
@@ -25,6 +35,8 @@ module "cloudfront" {
   s3_bucket_regional_domain_name = module.s3_frontend.bucket_regional_domain_name
   api_origin_domain_name         = local.api_domain_name
   acm_certificate_arn_us_east_1  = var.acm_certificate_arn_us_east_1
+  alb_origin_verify_header_name  = local.alb_origin_verify_header_name
+  alb_origin_verify_header_value = random_password.alb_origin_verify_header.result
 }
 
 # --- Reliability Pillar: DNS ---

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -7,10 +7,11 @@
 module "security_groups" {
   source = "../../modules/security/security-groups"
 
-  vpc_id         = module.vpc.vpc_id
-  project_name   = var.project_name
-  environment    = var.environment
-  container_port = var.container_port
+  vpc_id                                  = module.vpc.vpc_id
+  project_name                            = var.project_name
+  environment                             = var.environment
+  container_port                          = var.container_port
+  cloudfront_origin_facing_prefix_list_id = "pl-58a04531"
 }
 
 # --- Security Pillar: IAM ---

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -59,12 +59,14 @@ module "codedeploy" {
 module "load_balancer" {
   source = "../../modules/compute/load-balancer"
 
-  project_name           = var.project_name
-  alb_security_group_id  = module.security_groups.alb_security_group_id
-  public_subnet_ids      = module.vpc.public_subnet_ids
-  alb_listener_port      = var.alb_listener_port
-  blue_target_group_arn  = module.codedeploy.blue_target_group_arn
-  green_target_group_arn = module.codedeploy.green_target_group_arn
+  project_name                   = var.project_name
+  alb_security_group_id          = module.security_groups.alb_security_group_id
+  public_subnet_ids              = module.vpc.public_subnet_ids
+  alb_listener_port              = var.alb_listener_port
+  blue_target_group_arn          = module.codedeploy.blue_target_group_arn
+  green_target_group_arn         = module.codedeploy.green_target_group_arn
+  alb_origin_verify_header_name  = local.alb_origin_verify_header_name
+  alb_origin_verify_header_value = random_password.alb_origin_verify_header.result
 }
 
 # --- Performance + Cost Optimization Pillar: ECS ---

--- a/terraform/environments/dev/provider.tf
+++ b/terraform/environments/dev/provider.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/aws" # HashiCorp 公式 AWS プロバイダー
       version = "~> 6.8.0"      # 6.8.x 系列の最新版を使用
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
   # Terraform コアの最低バージョン要件
   # 1.0 以上で安定した HCL 構文と機能を保証

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -170,3 +170,9 @@ variable "enable_cloudfront" {
   type        = bool
   default     = true
 }
+
+variable "alb_origin_secret_rotation_version" {
+  description = "Version string used to rotate the CloudFront-to-ALB origin verification secret."
+  type        = string
+  default     = "v1"
+}

--- a/terraform/modules/cdn/cloudfront/main.tf
+++ b/terraform/modules/cdn/cloudfront/main.tf
@@ -38,6 +38,11 @@ resource "aws_cloudfront_distribution" "main" {
     # 例: api.hamilcar-hannibal.click
 
     origin_id = "ALB-${var.project_name}-API" # CloudFrontに複数の origin がある場合の識別に使用する
+    custom_header {
+      name  = var.alb_origin_verify_header_name
+      value = var.alb_origin_verify_header_value
+    }
+
     custom_origin_config {
       http_port                = 80
       https_port               = 443

--- a/terraform/modules/cdn/cloudfront/variables.tf
+++ b/terraform/modules/cdn/cloudfront/variables.tf
@@ -33,3 +33,14 @@ variable "acm_certificate_arn_us_east_1" {
   description = "ACM Certificate ARN for CloudFront (must be in us-east-1)"
   type        = string
 }
+
+variable "alb_origin_verify_header_name" {
+  description = "Header name CloudFront adds when forwarding API requests to the ALB origin"
+  type        = string
+}
+
+variable "alb_origin_verify_header_value" {
+  description = "Secret header value CloudFront adds when forwarding API requests to the ALB origin"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/modules/compute/load-balancer/main.tf
+++ b/terraform/modules/compute/load-balancer/main.tf
@@ -96,6 +96,13 @@ resource "aws_lb_listener_rule" "production_https" {
     }
   }
 
+  condition {
+    http_header {
+      http_header_name = var.alb_origin_verify_header_name
+      values           = [var.alb_origin_verify_header_value]
+    }
+  }
+
   lifecycle {
     # CodeDeployによる動的切替を許容
     ignore_changes = [action]
@@ -126,7 +133,56 @@ resource "aws_lb_listener_rule" "test" {
     }
   }
 
+  condition {
+    http_header {
+      http_header_name = var.alb_origin_verify_header_name
+      values           = [var.alb_origin_verify_header_value]
+    }
+  }
+
   lifecycle {
     ignore_changes = [action]
+  }
+}
+
+resource "aws_lb_listener_rule" "production_https_deny_without_origin_header" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 200
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access denied"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "test_deny_without_origin_header" {
+  listener_arn = aws_lb_listener.test.arn
+  priority     = 200
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access denied"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
   }
 }

--- a/terraform/modules/compute/load-balancer/variables.tf
+++ b/terraform/modules/compute/load-balancer/variables.tf
@@ -28,3 +28,14 @@ variable "green_target_group_arn" {
   description = "ARN of the green target group"
   type        = string
 }
+
+variable "alb_origin_verify_header_name" {
+  description = "Header name required for CloudFront-originated ALB requests"
+  type        = string
+}
+
+variable "alb_origin_verify_header_value" {
+  description = "Secret header value required for CloudFront-originated ALB requests"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/modules/security/security-groups/main.tf
+++ b/terraform/modules/security/security-groups/main.tf
@@ -1,9 +1,5 @@
 # Security Groups for Three-tier Architecture (Least Privilege)
 
-data "aws_ec2_managed_prefix_list" "cloudfront_origin_facing" {
-  name = "com.amazonaws.global.cloudfront.origin-facing"
-}
-
 # --- ALB Security Group ---
 resource "aws_security_group" "alb" {
   name        = "${var.project_name}-alb-sg"
@@ -17,7 +13,7 @@ resource "aws_security_group" "alb" {
     from_port       = 80
     to_port         = 8080
     protocol        = "tcp"
-    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront_origin_facing.id]
+    prefix_list_ids = [var.cloudfront_origin_facing_prefix_list_id]
   }
 
   # Allow all outbound traffic

--- a/terraform/modules/security/security-groups/main.tf
+++ b/terraform/modules/security/security-groups/main.tf
@@ -1,36 +1,23 @@
 # Security Groups for Three-tier Architecture (Least Privilege)
 
+data "aws_ec2_managed_prefix_list" "cloudfront_origin_facing" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 # --- ALB Security Group ---
 resource "aws_security_group" "alb" {
   name        = "${var.project_name}-alb-sg"
   description = "ALB security group for three-tier architecture"
   vpc_id      = var.vpc_id
 
-  # HTTP Redirect Listener (Port 80)
+  # CloudFront managed prefix list has weight 55, so the ALB listener range is kept
+  # in one rule to stay within the default security group rule quota.
   ingress {
-    description = "HTTP from internet"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Test Listener for Blue/Green (Port 8080)
-  ingress {
-    description = "Test HTTPS from internet"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # HTTPS Listener (Port 443)
-  ingress {
-    description = "HTTPS from internet"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description     = "ALB listeners from CloudFront origin-facing addresses"
+    from_port       = 80
+    to_port         = 8080
+    protocol        = "tcp"
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront_origin_facing.id]
   }
 
   # Allow all outbound traffic

--- a/terraform/modules/security/security-groups/variables.tf
+++ b/terraform/modules/security/security-groups/variables.tf
@@ -18,3 +18,8 @@ variable "container_port" {
   type        = number
   default     = 3000
 }
+
+variable "cloudfront_origin_facing_prefix_list_id" {
+  description = "AWS managed prefix list ID for CloudFront origin-facing addresses (com.amazonaws.global.cloudfront.origin-facing)"
+  type        = string
+}


### PR DESCRIPTION
## 目的（推奨）
CloudFront 経由の公開を維持しつつ、public ALB への直接アクセスを制限する。
Trivy Config の public ALB 検出に対して、即時 internal 化ではなく既存経路を保った段階的な緩和策を入れる。

## 変更内容（推奨）
- ALB security group の ingress を `0.0.0.0/0` から CloudFront origin-facing managed prefix list に制限
- CloudFront の ALB origin に `X-Hannibal-Origin-Verify` custom header を追加
- ALB 443 / 8080 listener rule で secret header 一致時のみ target group へ forward し、それ以外は `403` を返す
- secret header value を Terraform `random_password` で生成し、rotation version で再生成可能にする
- public ALB を維持する理由、prefix list quota、rotation 方針を docs に追記

## 影響範囲（推奨）
- **対象**: dev Terraform の CloudFront API origin、ALB listener rule、ALB security group、関連 docs
- **非対象**: `aws_lb.main.internal = true` への移行、CloudFront VPC origins、WAF 有効化、Terraform apply

## PRラベル（必須）
- **type**: `type:infra`
- **area**: `area:infra`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）: Terraform apply 時に CloudFront distribution / ALB listener rule / security group rule の更新が入る。CloudFront 反映には伝播時間がある。
**コスト根拠**（小/中/大の場合）: 新規有料リソースは追加しない。`random` provider と listener rule / security group rule / CloudFront origin header の設定変更のみ。
**リスク根拠**（Medium/Highの場合）: Network/Security と ALB 経路に関わる変更。CloudFront header と ALB rule の不整合があると API origin 通信が `403` になる可能性がある。

</details>

## 可観測性/検証 *条件付き*
- `terraform init`
- `terraform fmt -check -recursive`
- `terraform validate`
- `tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact`
- `git diff --check`
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*
この PR を revert し、Terraform apply で以下を前状態へ戻す。

- ALB security group ingress を元の `0.0.0.0/0` 許可へ戻す
- CloudFront ALB origin の custom header を削除する
- ALB 443 / 8080 listener rule の secret header 条件と fallback `403` rule を削除する
- `random` provider / origin secret rotation 変数を削除する

## リリース連携（推奨）
- **リリースノート**: 要

<details>
<summary>テスト結果/検証手順</summary>

```text
terraform init
terraform fmt -check -recursive
terraform validate
tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact
git diff --check
npm run commitlint -- --from main --to HEAD --verbose
```

</details>

## メモ（レビューポイント）
- `aws_lb.main.internal = true` は CloudFront VPC origins を含む private origin 移行として別設計に分離
- CloudFront managed prefix list は weight 55 のため、SG quota を避ける目的で TCP `80-8080` を1本の rule にまとめている
- CodeDeploy との干渉を避けるため、listener default action ではなく fallback listener rule で `403` を返す


Closes #232
