### PR TITLE
docs: record PR quality gate required decision

### DIFF
--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -30,6 +30,8 @@
 - Issue 本文に専用の運用区分欄は追加せず、軽運用 / 厳密運用の判定は起票前プランと PR 作成前プランで確認する
 - PR テンプレの `目的 / 変更内容 / 影響範囲` は推奨に留め、厳密運用PRでは `ロールバック` を必須にする
 - PR title と PR 内コミットメッセージは `Commitlint` job で Conventional Commits 形式を検査する
+- `TFLint` と `Gitleaks Secret Scan` は #228 で required status checks に追加した
+- `Trivy Config Scan` は HIGH / CRITICAL finding を review signal として表示するが、#228 時点では blocking gate にしない
 
 ### 軽運用 / 厳密運用
 
@@ -89,6 +91,17 @@ commitlint / Conventional Commits の運用ルール正本は [CONTRIBUTING.md](
 `Commitlint` job は独立した check として追加します。
 これにより、ラベル・Issueリンク・ロールバック欄を見る `PR Policy Check` と、コミット/PR title の形式検査を分離し、失敗時の原因を読み取りやすくします。
 required status check として扱う場合は、workflow 追加後に GitHub の branch protection 設定も同期します。
+
+### PR 品質ゲート required 化方針
+
+#227 で追加した `TFLint` / `Trivy Config Scan` / `Gitleaks Secret Scan` は、初期導入時点では branch protection の required status checks に含めず、観察期間後に #228 で判断しました。
+
+#228 では、#227 マージ後の `PR Check` workflow 実行履歴を確認し、`TFLint` と `Gitleaks Secret Scan` を required status checks に追加しました。
+どちらも観察期間中の実行が安定しており、検出時に PR を止める価値が高いためです。
+
+`Trivy Config Scan` は #228 時点では required status check に追加しません。
+現在の workflow は `exit-code: 0` で、HIGH / CRITICAL finding があっても job を成功させます。
+既存の finding には、旧 CloudFormation 資産、Dockerfile root user、WAF 無効化、KMS / CMK 系の accepted risk 候補が含まれるため、blocking gate にする前に修正対象・accepted risk・ignore 対象を整理します。
 
 ## 未採用案と理由
 
@@ -182,9 +195,9 @@ gate job の役割:
 
 **現在の required status checks（参考）**
 
-`PR Policy Check` / `Backend Lint & Build` / `Frontend Build` / `Terraform Format & Validate`
+`PR Policy Check` / `Commitlint` / `Backend Lint & Build` / `Frontend Build` / `Terraform Format & Validate` / `TFLint` / `Gitleaks Secret Scan`
 
-`Terraform Plan Change Detection` / `Terraform Plan Artifact` はいずれも required に含まれていない。
+`Trivy Config Scan` / `Terraform Plan Change Detection` / `Terraform Plan Artifact` は required に含まれていない。
 
 ## 将来の再検討条件
 

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -10,12 +10,12 @@
 
 ## PR チェック
 
-| Job | ツール | 役割 | 初期導入時の扱い |
+| Job | ツール | 役割 | 2026-05-22 時点の扱い |
 |---|---|---|---|
 | `Terraform Format & Validate` | `terraform fmt` / `terraform validate` | HCL の整形と Terraform 構成の基本整合性を確認 | required status check 対象 |
-| `TFLint` | `tflint` | Terraform / AWS provider 向けの lint。非推奨設定、未使用宣言、provider 固有のミスを検出 | PR で自動実行し、検出時は fail |
-| `Trivy Config Scan` | `trivy config` | Terraform / Dockerfile などの IaC・設定ミスを検出 | PR で自動実行。初期導入時点では review signal として扱い、検出しても fail しない |
-| `Gitleaks Secret Scan` | `gitleaks` | Git 履歴に混入した API key / token / password などの secret を検出 | PR で自動実行し、検出時は fail |
+| `TFLint` | `tflint` | Terraform / AWS provider 向けの lint。非推奨設定、未使用宣言、provider 固有のミスを検出 | required status check 対象。検出時は fail |
+| `Trivy Config Scan` | `trivy config` | Terraform / Dockerfile などの IaC・設定ミスを検出 | PR で自動実行。review signal として扱い、検出しても fail しない |
+| `Gitleaks Secret Scan` | `gitleaks` | Git 履歴に混入した API key / token / password などの secret を検出 | required status check 対象。検出時は fail |
 
 ## ツールの位置づけ
 
@@ -56,10 +56,46 @@ branch protection の required status checks にはすぐ追加しません。
 - 既存 IaC に対する false positive / accepted risk の棚卸しが必要
 - 実行時間と運用安定性を見てから required 化したほうが、日常PRを詰まらせにくい
 
-required status checks への追加は、#228 で判断します。
+required status checks への追加は、#228 で判断しました。
 
-#228 では、#227 マージから約1週間後の **2026年5月21日 JST 目安**で、false positive・実行時間・PR運用への影響を確認し、`TFLint` / `Gitleaks Secret Scan` / `Trivy Config Scan` を required 化するか判断します。
-ただし `Gitleaks` で secret 検出、または `TFLint` で明確な設定ミスが出た場合は、2026年5月21日を待たずに優先判断します。
+## #228 required 化判断
+
+#227 は 2026年5月14日 15:25 JST にマージされました。
+#228 では、観察期間後の 2026年5月22日 JST に、false positive・実行時間・PR運用への影響を確認しました。
+
+### 実行結果
+
+#227 以降の `PR Check` workflow 実行履歴を確認した結果、対象3jobはいずれも安定して完了していました。
+
+| Job | 結果 | 実行時間 | 判断 |
+|---|---:|---:|---|
+| `TFLint` | 54 / 54 success | 平均19秒、最大26秒 | required 化する |
+| `Gitleaks Secret Scan` | 54 / 54 success | 平均23秒、最大27秒 | required 化する |
+| `Trivy Config Scan` | 54 / 54 success | 平均19秒、最大46秒 | required 化しない |
+
+同期間に `PR Check` workflow 全体の失敗はありましたが、失敗した job は `Terraform Plan Artifact` であり、`TFLint` / `Gitleaks Secret Scan` / `Trivy Config Scan` ではありませんでした。
+
+### 判断
+
+`TFLint` は、観察期間中に false positive や実行時間の問題が見られず、Terraform / AWS provider 向けの実務 lint として PR を止める価値が高いため required status check に追加します。
+
+`Gitleaks Secret Scan` は、secret 混入時に PR マージを止めるべき性質が強く、観察期間中も安定していたため required status check に追加します。
+
+`Trivy Config Scan` は、引き続き review signal として扱います。
+現在の workflow は `exit-code: 0` のため、HIGH / CRITICAL finding が存在しても job は成功します。
+そのため `Trivy Config Scan` を required status check に追加しても、現状では finding を理由に PR を止める gate にはなりません。
+
+`Trivy Config Scan` を blocking gate にする場合は、次の整理を先に行います。
+
+- 旧 CloudFormation 資産を scan 対象に残すか、別管理に切り分けるか判断する
+- Dockerfile の root user を修正するか accepted risk として扱うか判断する
+- WAF 無効化、KMS / CMK、CloudTrail / Athena / SNS 暗号化の finding を修正対象・accepted risk・ignore 対象に分類する
+- accepted risk / ignore の理由を docs に残したうえで、`exit-code: 1` への変更を別 Issue で検討する
+
+### ロールバック
+
+required 化後に運用上の問題が出た場合は、branch protection の required status checks から `TFLint` / `Gitleaks Secret Scan` を外します。
+この docs 更新自体は該当 PR を revert して戻します。
 
 ## ローカル検証
 

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -97,6 +97,33 @@ required status checks への追加は、#228 で判断しました。
 required 化後に運用上の問題が出た場合は、branch protection の required status checks から `TFLint` / `Gitleaks Secret Scan` を外します。
 この docs 更新自体は該当 PR を revert して戻します。
 
+branch protection は Git 管理外の GitHub 設定です。
+そのため、docs の revert だけでは required status checks は戻りません。
+設定変更後は次のコマンドで実設定を確認します。
+
+```bash
+gh api repos/:owner/:repo/branches/main/protection/required_status_checks \
+  --jq '{strict, contexts}'
+```
+
+`TFLint` / `Gitleaks Secret Scan` を required status checks から外す場合は、`contexts` から2つを除いた一覧で branch protection を更新します。
+
+```bash
+jq -n '{
+  strict: false,
+  contexts: [
+    "PR Policy Check",
+    "Backend Lint & Build",
+    "Frontend Build",
+    "Terraform Format & Validate",
+    "Commitlint"
+  ]
+}' \
+  | gh api --method PATCH \
+      repos/:owner/:repo/branches/main/protection/required_status_checks \
+      --input -
+```
+
 ## ローカル検証
 
 ```bash


### PR DESCRIPTION
## 目的（推奨）

#228 の判断として、#227 で追加した PR 品質ゲートの required 化可否を記録し、branch protection の状態と docs を揃える。

## 変更内容（推奨）

- `TFLint` / `Gitleaks Secret Scan` を required status checks に追加した判断を記録
- `Trivy Config Scan` は `exit-code: 0` の review signal として継続する理由を記録
- #227 後の実行結果、実行時間、ロールバック手順を `quality-gates.md` に追記
- `github-flow-guardrails.md` の required checks 参考欄を更新

## 影響範囲（推奨）

- **対象**: GitHub branch protection required status checks、PR 品質ゲート docs
- **非対象**: Terraform / AWS リソース、workflow の実行内容、Trivy の blocking 化

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:ci-cd`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。branch protection と docs の変更のみ。
**コスト根拠**: AWS リソース変更なし。GitHub Actions job 追加もなし。
**リスク根拠**: branch protection required status checks に `TFLint` / `Gitleaks Secret Scan` を追加し、PR マージ可否に影響するため `risk:medium`。

</details>

## 可観測性/検証 *条件付き*

- `git diff --check`
- `npm run commitlint -- --from main --to HEAD --verbose`
- PR title の commitlint
- `gh api repos/:owner/:repo/branches/main/protection/required_status_checks --jq '{strict, contexts}'`

## ロールバック *条件付き*

- branch protection の required status checks から `TFLint` / `Gitleaks Secret Scan` を外す
- この PR を revert して docs の判断記録を戻す

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

`TFLint` / `Gitleaks Secret Scan` / `Trivy Config Scan` は #227 後の `PR Check` workflow で各 54 / 54 success。
同期間の `PR Check` workflow failure は `Terraform Plan Artifact` によるもので、今回対象の3jobではないことを確認。

</details>

## メモ（レビューポイント）

- `Trivy Config Scan` は required status check に追加しない
- `Trivy Config Scan` の blocking 化は accepted risk / ignore 整理後に別 Issue で検討する


Closes #228
