### PR TITLE
infra: ALB証明書ARNを変数化する

### DIFF
--- a/docs/terraform-environments.md
+++ b/docs/terraform-environments.md
@@ -41,7 +41,8 @@
 | `project_name` | `"nestjs-hannibal-3"` | 必要なら環境別サフィックスを付ける |
 | `domain_name` | `"hamilcar-hannibal.click"` | 本番ドメインに変更 |
 | `hosted_zone_id` | 既存 Zone ID | prod 用 Route53 Zone を用意（または同一 Zone でサブドメイン分離） |
-| `acm_certificate_arn_us_east_1` | dev 用 ACM ARN | prod 用 ACM 証明書（us-east-1 必須） |
+| `acm_certificate_arn_us_east_1` | dev 用 CloudFront ACM ARN | prod 用 CloudFront 証明書（us-east-1 必須） |
+| `alb_certificate_arn` | dev 用 ALB ACM ARN | prod 用 ALB 証明書（ALB と同じリージョン） |
 | `client_url_for_cors` | `"https://hamilcar-hannibal.click"` | prod ドメインに変更 |
 | `db_instance_class` | `db.t3.micro` | prod は `db.t3.small` 以上推奨 |
 | `desired_task_count` | `1` | prod は `2` 以上推奨（Multi-AZ と合わせて） |

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -64,6 +64,7 @@ module "load_balancer" {
   alb_security_group_id          = module.security_groups.alb_security_group_id
   public_subnet_ids              = module.vpc.public_subnet_ids
   alb_listener_port              = var.alb_listener_port
+  alb_certificate_arn            = var.alb_certificate_arn
   blue_target_group_arn          = module.codedeploy.blue_target_group_arn
   green_target_group_arn         = module.codedeploy.green_target_group_arn
   alb_origin_verify_header_name  = local.alb_origin_verify_header_name

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -53,6 +53,12 @@ variable "alb_listener_port" {
   default     = 80
 }
 
+variable "alb_certificate_arn" {
+  description = "ACM certificate ARN for ALB HTTPS listeners. The certificate must exist in aws_region."
+  type        = string
+  default     = "arn:aws:acm:ap-northeast-1:258632448142:certificate/9ab350e8-1748-4e17-aa89-9db7c889b146"
+}
+
 variable "health_check_path" {
   description = "Path for ALB health check"
   type        = string

--- a/terraform/environments/prod/README.md
+++ b/terraform/environments/prod/README.md
@@ -28,7 +28,8 @@
    - `environment = "prod"`
    - `domain_name`（prod ドメインまたはサブドメイン）
    - `hosted_zone_id`
-   - `acm_certificate_arn_us_east_1`（us-east-1 の ACM ARN）
+   - `acm_certificate_arn_us_east_1`（CloudFront 用。us-east-1 の ACM ARN）
+   - `alb_certificate_arn`（ALB 用。`aws_region` と同じリージョンの ACM ARN）
    - `db_instance_class`（prod は `db.t3.small` 以上推奨）
    - `desired_task_count`（prod は `2` 以上推奨）
 

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -10,8 +10,11 @@ aws_region   = "ap-northeast-1"
 domain_name    = "prod.hamilcar-hannibal.click"
 hosted_zone_id = "<prod 用 Route53 Hosted Zone ID>"
 
-# ACM 証明書（us-east-1 で発行した prod 用 ARN）
+# ACM 証明書（CloudFront 用。us-east-1 で発行した prod 用 ARN）
 acm_certificate_arn_us_east_1 = "arn:aws:acm:us-east-1:<account-id>:certificate/<cert-id>"
+
+# ACM 証明書（ALB 用。aws_region と同じリージョンで発行した prod 用 ARN）
+alb_certificate_arn = "arn:aws:acm:ap-northeast-1:<account-id>:certificate/<cert-id>"
 
 # CORS
 client_url_for_cors = "https://prod.hamilcar-hannibal.click"

--- a/terraform/modules/compute/load-balancer/main.tf
+++ b/terraform/modules/compute/load-balancer/main.tf
@@ -1,8 +1,3 @@
-# --- ALB (Application Load Balancer) ---
-locals {
-  alb_certificate_arn = "arn:aws:acm:ap-northeast-1:258632448142:certificate/9ab350e8-1748-4e17-aa89-9db7c889b146"
-}
-
 resource "aws_lb" "main" {
   name                       = "${var.project_name}-alb"
   internal                   = false
@@ -38,7 +33,7 @@ resource "aws_lb_listener" "https" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = local.alb_certificate_arn
+  certificate_arn   = var.alb_certificate_arn
 
   default_action {
     type = "forward"
@@ -57,7 +52,7 @@ resource "aws_lb_listener" "test" {
   port              = 8080
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = local.alb_certificate_arn
+  certificate_arn   = var.alb_certificate_arn
 
   default_action {
     type = "forward"

--- a/terraform/modules/compute/load-balancer/variables.tf
+++ b/terraform/modules/compute/load-balancer/variables.tf
@@ -19,6 +19,11 @@ variable "alb_listener_port" {
   default     = 80
 }
 
+variable "alb_certificate_arn" {
+  description = "ACM certificate ARN for ALB HTTPS listeners. The certificate must exist in the ALB region."
+  type        = string
+}
+
 variable "blue_target_group_arn" {
   description = "ARN of the blue target group"
   type        = string


### PR DESCRIPTION
## 目的
ALB HTTPS listener の証明書 ARN を module 内固定値から環境ごとの Terraform variable に移し、環境固有値を整理しやすくする。

## 変更内容
ALB listener の `certificate_arn` を `var.alb_certificate_arn` 経由に変更し、dev / prod example / 環境分離 docs の設定項目を揃える。

## 影響範囲
- **対象**: Terraform load-balancer module、dev root module、prod 設定例、環境分離 docs
- **非対象**: AWS apply、証明書の作成・差し替え、GitHub Actions の変数化

## PRラベル（必須）
- **type**: type:infra
- **area**: area:infra, area:docs
- **risk**: risk:medium
- **cost**: cost:none

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠（Medium）**: terraform/** 変更かつ module インターフェース変更。ただし apply は行わず、コード整理と検証のみ。

</details>

## 可観測性/検証
- `terraform fmt -check -recursive`: 成功
- `terraform -chdir=terraform/environments/dev validate`: 成功
- `terraform plan -refresh=false -lock=false`: 成功（75 to add, 0 to change, 0 to destroy）
- `commitlint`: 成功

## ロールバック
PR を revert すれば、module 内固定値を使う以前の構成に戻せる。AWS リソース変更は行っていないため、追加のクラウド側操作は不要。

## リリース連携
- **リリースノート**: 不要


Closes #251
