### PR TITLE
ci: ロールARNをGitHub Variablesに外出しし、workflowからアカウントIDを除去する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy NestJS Hannibal
 
 env:
-  AWS_ACCOUNT_ID: "258632448142"
   PROJECT_NAME: "nestjs-hannibal-3"
-  AWS_REGION: "ap-northeast-1"
   TERRAFORM_VERSION: "1.12.1"
   NODE_VERSION: "20"
 
@@ -55,8 +53,8 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/HannibalCICDRole-Dev
-          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_CICD_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Install prerequisites
         run: |
@@ -131,13 +129,14 @@ jobs:
           fi
 
       - name: Login to Amazon ECR
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       # 方式A: SHAタグとlatestタグの両方をPush（0回目でもlatestをPull可能にする）
       - name: Build and Push ECS Image
         run: |
           set -e
-          REPO="${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PROJECT_NAME }}"
+          REPO="${{ steps.login-ecr.outputs.registry }}/${{ env.PROJECT_NAME }}"
           IMAGE_SHA_TAG="$REPO:${{ github.sha }}"
           IMAGE_LATEST_TAG="$REPO:latest"
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,9 +1,7 @@
 name: Destroy AWS Infrastructure (Reliable)
 
 env:
-  AWS_ACCOUNT_ID: "258632448142"
   PROJECT_NAME: "nestjs-hannibal-3"
-  AWS_REGION: "ap-northeast-1"
   TERRAFORM_VERSION: "1.12.1"
 
 on:
@@ -26,8 +24,8 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/HannibalCICDRole-Dev
-          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_CICD_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,8 +9,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCOUNT_ID: "258632448142"
-  AWS_REGION: "ap-northeast-1"
   TERRAFORM_VERSION: "1.12.1"
   NODE_VERSION: "20"
 
@@ -564,8 +562,8 @@ jobs:
       - name: Configure AWS credentials for PR plan
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/HannibalPRPlanRole-Dev
-          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_PR_PLAN_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform Init (dev backend)
         working-directory: ./terraform/environments/dev


### PR DESCRIPTION
## 目的

GitHub Actions workflow からアカウントIDおよびロール ARN を除去し、GitHub Variables に外出しする。ロールや環境が変わっても workflow ファイルを変更せず Variables の更新だけで対応できるようにする。

## 変更内容

- `AWS_ACCOUNT_ID` env var を deploy / destroy / pr-check の全 workflow から削除
- `role-to-assume` を `${{ vars.AWS_CICD_ROLE_ARN }}` / `${{ vars.AWS_PR_PLAN_ROLE_ARN }}` に変更
- `aws-region` を `${{ vars.AWS_REGION }}` に変更
- deploy.yml の ECR URL 構築を `amazon-ecr-login@v2` の `registry` output に切り替え
- GitHub Variables に `AWS_CICD_ROLE_ARN` / `AWS_PR_PLAN_ROLE_ARN` / `AWS_REGION` を登録済み

## 影響範囲

- **対象**: `.github/workflows/deploy.yml`、`.github/workflows/destroy.yml`、`.github/workflows/pr-check.yml`
- **非対象**: Terraform コード、AWS リソースの実効内容

## 可観測性/検証

- GitHub Variables 登録確認済み（`gh variable list`）
- deploy / destroy / PR plan の CI 動作確認は次回の workflow 実行時

## ロールバック

GitHub Variables を削除し、workflow ファイルを revert することで元の状態に戻せる。Variables は先に登録済みのため、このブランチをマージしても Variables 未登録による即時障害は発生しない。

## リリース連携

- **リリースノート**: 不要

Closes #259


Closes #259
