### PR TITLE
infra: HannibalECSBoundary.json を templatefile() に切り替えてアカウントIDを除去する

### DIFF
--- a/terraform/foundation/HannibalECSBoundary.json
+++ b/terraform/foundation/HannibalECSBoundary.json
@@ -27,8 +27,8 @@
         "logs:PutRetentionPolicy"
       ],
       "Resource": [
-        "arn:aws:logs:ap-northeast-1:258632448142:log-group:/ecs/nestjs-hannibal-3-*",
-        "arn:aws:logs:ap-northeast-1:258632448142:log-group:/ecs/nestjs-hannibal-3-*:*"
+        "arn:aws:logs:ap-northeast-1:${account_id}:log-group:/ecs/nestjs-hannibal-3-*",
+        "arn:aws:logs:ap-northeast-1:${account_id}:log-group:/ecs/nestjs-hannibal-3-*:*"
       ]
     },
     {
@@ -39,9 +39,9 @@
         "secretsmanager:DescribeSecret"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:ap-northeast-1:258632448142:secret:nestjs-hannibal-3/*",
-        "arn:aws:secretsmanager:ap-northeast-1:258632448142:secret:nestjs-hannibal-3-*",
-        "arn:aws:secretsmanager:ap-northeast-1:258632448142:secret:rds!*"
+        "arn:aws:secretsmanager:ap-northeast-1:${account_id}:secret:nestjs-hannibal-3/*",
+        "arn:aws:secretsmanager:ap-northeast-1:${account_id}:secret:nestjs-hannibal-3-*",
+        "arn:aws:secretsmanager:ap-northeast-1:${account_id}:secret:rds!*"
       ]
     },
     {
@@ -52,7 +52,7 @@
         "kms:DescribeKey",
         "kms:GenerateDataKey"
       ],
-      "Resource": "arn:aws:kms:ap-northeast-1:258632448142:key/*",
+      "Resource": "arn:aws:kms:ap-northeast-1:${account_id}:key/*",
       "Condition": {
         "StringEquals": {
           "kms:ViaService": [
@@ -69,7 +69,7 @@
       "Action": [
         "rds-db:connect"
       ],
-      "Resource": "arn:aws:rds-db:ap-northeast-1:258632448142:dbuser:nestjs-hannibal-3-*/*"
+      "Resource": "arn:aws:rds-db:ap-northeast-1:${account_id}:dbuser:nestjs-hannibal-3-*/*"
     },
     {
       "Sid": "CodeDeployECS",

--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -428,7 +428,7 @@ resource "aws_iam_policy" "hannibal_ecs_boundary" {
   name        = "HannibalECSBoundary"
   description = "Permission Boundary for ECS Task Execution Role - Hannibal Project"
 
-  policy = file("${path.module}/HannibalECSBoundary.json")
+  policy = templatefile("${path.module}/HannibalECSBoundary.json", { account_id = data.aws_caller_identity.current.account_id })
 }
 
 # --- 8. HannibalCICDPolicy-Dev-* (CI/CD最小権限ポリシー・3分割) ---


### PR DESCRIPTION
## 目的

`terraform/foundation/HannibalECSBoundary.json` 内のアカウントIDを除去する。`file()` では Terraform の data source を埋め込めないため `templatefile()` に切り替え、`data.aws_caller_identity` からアカウントIDを動的に渡せるようにする。

## 変更内容

- `HannibalECSBoundary.json`: `258632448142` → `${account_id}` プレースホルダーに置換（5箇所）
- `iam.tf`: `policy = file(...)` → `policy = templatefile(..., { account_id = data.aws_caller_identity.current.account_id })`

## 影響範囲

- **対象**: `terraform/foundation/HannibalECSBoundary.json`、`terraform/foundation/iam.tf`
- **非対象**: ポリシーの実効内容（変更前後で同一）

## 可観測性/検証

- `terraform fmt -check -recursive`: ✅ パス
- `terraform validate` (foundation): ✅ Success
- `terraform plan` (foundation): AWS 認証ありで人間が確認

## ロールバック

`templatefile()` を `file()` に戻し、JSON の `${account_id}` を固定値に戻す。ポリシー内容は変わらないため apply 済みでも安全に revert できる。

## リリース連携

- **リリースノート**: 不要

Closes #258


Closes #258
