### PR TITLE
chore: import スクリプトのアカウントIDフォールバック値を除去する

### DIFF
--- a/scripts/import-dev-terraform-drift.sh
+++ b/scripts/import-dev-terraform-drift.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/../terraform/environments/dev"
 
-ACCOUNT_ID="${AWS_ACCOUNT_ID:-258632448142}"
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 PROJECT="nestjs-hannibal-3"
 ZONE_ID="Z06663901XRPJ5V5J5GIW"
 DOMAIN="hamilcar-hannibal.click"


### PR DESCRIPTION
## 目的

`scripts/import-dev-terraform-drift.sh` 内のアカウントIDフォールバック値を除去する。環境変数が未設定のまま実行されたとき、dev のアカウントIDがデフォルトとして使われてしまう状態を解消する。

## 変更内容

- `ACCOUNT_ID="${AWS_ACCOUNT_ID:-258632448142}"` を `ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"` に変更
- スクリプトは既に「実行前: AWS 認証済み」を前提とするため、動的取得で一貫性を保つ

## 影響範囲

- **対象**: `scripts/import-dev-terraform-drift.sh`
- **非対象**: CI/CD、AWS リソース、Terraform コード

## 可観測性/検証

- No-op（ローカル実行用スクリプトのみ）
- AWS 認証済み環境で実行すれば従来と同じ動作

## ロールバック

不要（ローカルスクリプトのみ、revert で即時復元可）

## リリース連携

- **リリースノート**: 不要

Closes #260


Closes #260
