### PR TITLE
chore: Dockerfile を非 root ユーザー実行に変更する

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -313,6 +313,22 @@ jobs:
         working-directory: ./client
         run: npm run build
 
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t hannibal-test .
+
+      - name: Verify non-root user
+        run: |
+          user=$(docker run --rm hannibal-test whoami)
+          echo "Container running as: $user"
+          [ "$user" = "node" ] || { echo "::error::Expected 'node' user, got '$user'"; exit 1; }
+
   terraform-check:
     name: Terraform Format & Validate
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /usr/src/app
 # RDS CA証明書をダウンロード
 RUN apk add --no-cache wget && \
     wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /opt/rds-ca-2019-root.pem && \
+    chmod 644 /opt/rds-ca-2019-root.pem && \
     apk del wget
 
 # 本番依存のみインストール
@@ -38,5 +39,7 @@ ENV PORT=3000
 ENV HOST=0.0.0.0
 
 EXPOSE 3000
+
+USER node
 
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## 目的
コンテナを非 root ユーザーで実行し、脆弱性を突かれた際のリスクを低減する。PR CI に docker build ジョブを追加して Dockerfile の破損を早期検知できるようにする。

## 変更内容
- `Dockerfile`: `chmod 644 /opt/rds-ca-2019-root.pem` 追加、`USER node` 追加
- `.github/workflows/pr-check.yml`: `docker-build` ジョブ追加（ビルド確認 + 非 root 検証）

## 影響範囲
- **対象**: ECS コンテナの実行ユーザー、PR CI
- **非対象**: インフラリソース、デプロイフロー

## ロールバック
- `git revert` で本 PR のコミットを戻す
- ECS タスクは前回イメージへの切り戻しが必要な場合は deploy.yml を再実行する

## 可観測性/検証
CI の `docker-build` ジョブが green になることで確認

## リリース連携
- **リリースノート**: 不要

Closes #269