### PR TITLE
infra: dev variables.tf の固定値ARN・URLをデフォルト値から除去する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,10 @@ jobs:
             -var="environment=dev" \
             -var="deployment_type=$DEPLOYMENT_TYPE" \
             -var="enable_cloudfront=true" \
+            -var="ecr_repository_url=${{ vars.ECR_REPOSITORY_URL }}" \
+            -var="alb_certificate_arn=${{ vars.ALB_CERTIFICATE_ARN }}" \
+            -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
+            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
             -out=tfplan
           terraform apply -auto-approve tfplan
           

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -87,7 +87,11 @@ jobs:
             -var="client_url_for_cors=" \
             -var="environment=dev" \
             -var="deployment_type=canary" \
-            -var="enable_cloudfront=true"
+            -var="enable_cloudfront=true" \
+            -var="ecr_repository_url=${{ vars.ECR_REPOSITORY_URL }}" \
+            -var="alb_certificate_arn=${{ vars.ALB_CERTIFICATE_ARN }}" \
+            -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
+            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}"
 
       - name: Cleanup S3 buckets (best-effort)
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -601,6 +601,10 @@ jobs:
             -var="environment=dev" \
             -var="deployment_type=canary" \
             -var="enable_cloudfront=true" \
+            -var="ecr_repository_url=${{ vars.ECR_REPOSITORY_URL }}" \
+            -var="alb_certificate_arn=${{ vars.ALB_CERTIFICATE_ARN }}" \
+            -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
+            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
             > terraform-plan.txt 2>&1
           plan_exit=$?
           set -e

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -14,7 +14,6 @@ variable "project_name" {
 variable "ecr_repository_url" {
   description = "ECR repository URL (manually created)"
   type        = string
-  default     = "258632448142.dkr.ecr.ap-northeast-1.amazonaws.com/nestjs-hannibal-3"
 }
 
 variable "container_port" {
@@ -50,7 +49,6 @@ variable "alb_listener_port" {
 variable "alb_certificate_arn" {
   description = "ACM certificate ARN for ALB HTTPS listeners. The certificate must exist in aws_region."
   type        = string
-  default     = "arn:aws:acm:ap-northeast-1:258632448142:certificate/9ab350e8-1748-4e17-aa89-9db7c889b146"
 }
 
 variable "health_check_path" {
@@ -156,13 +154,11 @@ variable "domain_name" {
 variable "hosted_zone_id" {
   description = "Route 53 Hosted Zone ID for the domain_name"
   type        = string
-  default     = "Z06663901XRPJ5V5J5GIW"
 }
 
 variable "acm_certificate_arn_us_east_1" {
   description = "ACM Certificate ARN for CloudFront (must be in us-east-1)"
   type        = string
-  default     = "arn:aws:acm:us-east-1:258632448142:certificate/85268053-8bc9-4210-a855-50530d41116d"
 }
 
 variable "cloudfront_oac_id" {


### PR DESCRIPTION
## 目的
dev 環境の `variables.tf` に残っていた固定値 ARN・URL（アカウント ID を含む）を `default` から除去し、GitHub Variables 経由で渡すように変更する。

## 変更内容
- `terraform/environments/dev/variables.tf`: `ecr_repository_url` / `alb_certificate_arn` / `acm_certificate_arn_us_east_1` / `hosted_zone_id` の `default` 値を除去
- `.github/workflows/deploy.yml` / `destroy.yml` / `pr-check.yml`: 上記4変数を `-var="...${{ vars.* }}"` で渡すよう追加
- GitHub Variables: `ECR_REPOSITORY_URL` / `ALB_CERTIFICATE_ARN` / `ACM_CERTIFICATE_ARN_US_EAST_1` / `HOSTED_ZONE_ID` を登録

## 影響範囲
- **対象**: Terraform plan/apply/destroy、PR CI の terraform-plan ジョブ
- **非対象**: アプリケーション、ECS タスク、既存インフラリソース

## ロールバック
- `git revert` で本 PR のコミットを戻す
- GitHub Variables は手動で削除または旧値に戻す（Settings → Secrets and variables → Variables）

## 可観測性/検証
CI の terraform-check / terraform-plan ジョブが green になることで確認

## リリース連携
- **リリースノート**: 不要

Closes #273