### PR TITLE
docs: SLO と Runbook を文書化する

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -7,6 +7,8 @@
 **関連ドキュメント:**
 - [iam-management.md](./iam-management.md) - IAM権限最適化（Athena分析）
 - [monitoring.md](./monitoring.md) - CloudWatch監視・CloudTrail分析
+- [slo.md](./slo.md) - SLO（レスポンスタイム・エラー率・稼働率）
+- [runbook.md](./runbook.md) - CloudWatch Alarm / ECS / デプロイ失敗時の対応手順
 - [quality-gates.md](./quality-gates.md) - PR品質ゲート（Terraform lint / IaC security / secret scan）
 - [pr-terraform-plan-role-design.md](./pr-terraform-plan-role-design.md) - PR terraform plan用AWS Role/OIDC権限設計補足
 - [docs/deployment/codedeploy-blue-green.md](../deployment/codedeploy-blue-green.md) - デプロイ詳細

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,222 @@
+# Runbook - NestJS Hannibal 3
+
+この Runbook は、CloudWatch Alarm またはデプロイ失敗を受けた時の初動手順をまとめる。
+AWS CLI 例では `ap-northeast-1` と `nestjs-hannibal-3` を前提にする。
+コマンド出力に secret や credential が含まれる可能性がある場合は、値を貼り付けずに状態だけ共有する。
+
+## 共通初動
+
+1. 通知された alarm 名、発生時刻、AWS region を確認する。
+2. CloudWatch Alarm の現在状態を確認する。
+3. 直近で GitHub Actions の `deploy.yml`、Terraform apply、CodeDeploy が動いていなかったか確認する。
+4. 利用者影響がある場合は、ALB 5xx、TargetResponseTime、ECS running count、ECS logs を優先して見る。
+5. デプロイ直後の悪化であれば、CodeDeploy の auto rollback または手動 rollback を優先する。
+
+共通確認コマンド:
+
+```bash
+PROJECT_NAME=nestjs-hannibal-3
+REGION=ap-northeast-1
+CLUSTER="${PROJECT_NAME}-cluster"
+SERVICE="${PROJECT_NAME}-api-service"
+LOG_GROUP="/ecs/${PROJECT_NAME}-api-task"
+
+aws cloudwatch describe-alarms \
+  --alarm-name-prefix "$PROJECT_NAME" \
+  --region "$REGION"
+
+aws ecs describe-services \
+  --cluster "$CLUSTER" \
+  --services "$SERVICE" \
+  --region "$REGION"
+
+aws logs tail "$LOG_GROUP" \
+  --since 30m \
+  --region "$REGION"
+```
+
+## CloudWatch Alarm 対応
+
+| Alarm                                                     | 主な意味                                     | 初動                                                                 |
+| --------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------- |
+| `nestjs-hannibal-3-ecs-cpu-high`                          | ECS CPU 5分平均が 70% 超過                   | traffic 増加、無限ループ、直近 deploy を確認する                     |
+| `nestjs-hannibal-3-ecs-memory-high`                       | ECS memory 5分平均が 75% 超過                | memory leak、OOM kill、直近 deploy を確認する                        |
+| `nestjs-hannibal-3-ecs-task-stopped`                      | ECS task 停止または running count 異常の疑い | ECS service と stopped task reason を確認する                        |
+| `nestjs-hannibal-3-rds-cpu-high`                          | RDS CPU 5分平均が 60% 超過                   | slow query、接続増加、アプリ retry を確認する                        |
+| `nestjs-hannibal-3-rds-connections-high`                  | RDS connections が 12 超過                   | connection leak、pool 設定、再試行増加を確認する                     |
+| `nestjs-hannibal-3-alb-response-time-high`                | ALB target response time が 1秒超過          | ECS/RDS/外部依存の遅延を切り分ける                                   |
+| `nestjs-hannibal-3-alb-5xx-error-rate-high`               | ALB target 5xx が 5分合計 5件超過            | ECS logs と直近 deploy を確認する                                    |
+| `nestjs-hannibal-3-canary-error-rate`                     | canary 中の 5xx 増加                         | CodeDeploy auto rollback の状態を確認する                            |
+| `nestjs-hannibal-3-canary-response-time`                  | canary 中の response time 悪化               | CodeDeploy auto rollback の状態を確認する                            |
+| `nestjs-hannibal-3-cloudtrail-root-account-usage`         | root account 利用検知                        | 正当性確認、不要なら認証情報保護と MFA 確認を行う                    |
+| `nestjs-hannibal-3-cloudtrail-iam-policy-change`          | IAM policy 変更検知                          | 変更者、変更内容、Issue / PR との対応を確認する                      |
+| `nestjs-hannibal-3-cloudtrail-configuration-change`       | CloudTrail 設定変更検知                      | 監査ログ停止や改ざん意図がないか確認する                             |
+| `nestjs-hannibal-3-cloudtrail-console-signin-without-mfa` | MFA なし console login 検知                  | 対象 principal を確認し、MFA 有効化と credential rotation を検討する |
+
+### ECS CPU high
+
+1. ECS service の `runningCount` / `desiredCount` と deployment 状態を確認する。
+2. CloudWatch Logs で error や同じ処理の連続実行がないか確認する。
+3. ALB `RequestCount` と `TargetResponseTime` が同時に増えているか確認する。
+4. 直近 deploy 後に発生した場合は CodeDeploy rollback を検討する。
+5. 継続的な負荷であれば、task CPU 増加または desired count 増加を Terraform 変更として Issue 化する。
+
+```bash
+aws ecs describe-services \
+  --cluster nestjs-hannibal-3-cluster \
+  --services nestjs-hannibal-3-api-service \
+  --query 'services[0].{status:status,running:runningCount,desired:desiredCount,deployments:deployments}' \
+  --region ap-northeast-1
+```
+
+### ECS memory high
+
+1. CloudWatch Logs で OOM、GC、同一リクエストの再試行を確認する。
+2. stopped task がある場合は `stoppedReason` と container の `reason` を確認する。
+3. 直近 deploy で増えた場合は前バージョンへの rollback を優先する。
+4. 継続的な増加であれば memory leak 調査 Issue を作る。
+
+### ECS task stopped
+
+ECS task 停止時は alarm 名だけで判断せず、ECS service の desired / running count と stopped task reason を正本にする。
+
+1. service の `runningCount` が `desiredCount` を下回っているか確認する。
+2. 直近停止した task ARN を取得する。
+3. `stoppedReason`、container `exitCode`、container `reason` を確認する。
+4. ECS logs で停止直前の error を確認する。
+5. よくある原因として、Secrets Manager 参照不可、ECR image pull 失敗、NAT 経路不備、RDS 接続失敗、memory 不足を確認する。
+
+```bash
+TASKS=$(aws ecs list-tasks \
+  --cluster nestjs-hannibal-3-cluster \
+  --service-name nestjs-hannibal-3-api-service \
+  --desired-status STOPPED \
+  --max-results 5 \
+  --query 'taskArns' \
+  --output text \
+  --region ap-northeast-1)
+
+aws ecs describe-tasks \
+  --cluster nestjs-hannibal-3-cluster \
+  --tasks $TASKS \
+  --query 'tasks[*].{task:taskArn,stoppedReason:stoppedReason,containers:containers[*].{name:name,exitCode:exitCode,reason:reason}}' \
+  --region ap-northeast-1
+```
+
+### RDS CPU / connections high
+
+1. ECS logs で DB timeout、connection refused、retry storm がないか確認する。
+2. RDS `CPUUtilization` と `DatabaseConnections` が同時に増えているか確認する。
+3. deploy 後に発生した場合はアプリ変更起因を疑い、rollback を検討する。
+4. connections だけが高い場合は connection pool 解放漏れや retry 設定を確認する。
+5. 継続する場合は query 調査、index、pool 上限、DB instance class 見直しを Issue 化する。
+
+### ALB response time high
+
+1. ALB `TargetResponseTime`、`HTTPCode_Target_5XX_Count`、ECS CPU / memory、RDS CPU / connections を同じ時間帯で見る。
+2. ECS / RDS のどちらも正常なら、アプリケーションログで遅い endpoint や GraphQL query を確認する。
+3. canary / bluegreen 中なら CodeDeploy の alarm と deployment status を確認する。
+4. 利用者影響が継続する場合は rollback を優先する。
+
+### ALB 5xx high
+
+1. ECS logs で exception、DB 接続エラー、起動失敗を確認する。
+2. ALB target health を確認し、unhealthy target が増えていないか見る。
+3. 直近 deploy がある場合は CodeDeploy deployment status を確認する。
+4. canary 中の 5xx であれば auto rollback を待つ。止まらない場合は手動停止する。
+
+```bash
+aws deploy list-deployments \
+  --application-name nestjs-hannibal-3-app \
+  --deployment-group-name nestjs-hannibal-3-dg \
+  --max-items 5 \
+  --region ap-northeast-1
+```
+
+### Canary alarms
+
+`nestjs-hannibal-3-canary-error-rate` または `nestjs-hannibal-3-canary-response-time` が ALARM になった場合、CodeDeploy は `DEPLOYMENT_STOP_ON_ALARM` で auto rollback する設定になっている。
+
+1. CodeDeploy deployment status を確認する。
+2. `Stopped` / `Failed` / `Succeeded` のどれかを確認する。
+3. rollback が進んでいる場合は完了まで待ち、ALB 5xx と response time が戻るか確認する。
+4. rollback しない場合は `stop-deployment --auto-rollback-enabled` を実行する。
+
+```bash
+DEPLOYMENT_ID=<deployment-id>
+
+aws deploy get-deployment \
+  --deployment-id "$DEPLOYMENT_ID" \
+  --region ap-northeast-1
+
+aws deploy stop-deployment \
+  --deployment-id "$DEPLOYMENT_ID" \
+  --auto-rollback-enabled \
+  --region ap-northeast-1
+```
+
+### CloudTrail security alarms
+
+CloudTrail security alarm は、利用者影響よりも監査性と権限保護を優先して扱う。
+
+1. CloudTrail Event history または CloudWatch Logs `/aws/cloudtrail/nestjs-hannibal-3` で対象 event を確認する。
+2. 変更者、source IP、eventName、userAgent を確認する。
+3. 対応する Issue / PR / GitHub Actions run があるか確認する。
+4. 正当な変更でなければ、該当 credential の無効化、MFA 状態確認、権限見直しを行う。
+5. CloudTrail 停止や IAM policy 変更が不審な場合は、以降の deploy / apply を止めて調査を優先する。
+
+## デプロイ失敗時の rollback
+
+### 自動 rollback
+
+CodeDeploy deployment group は次の event で auto rollback する。
+
+- `DEPLOYMENT_FAILURE`
+- `DEPLOYMENT_STOP_ON_ALARM`
+
+まずは CodeDeploy の状態を確認する。
+
+```bash
+aws deploy list-deployments \
+  --application-name nestjs-hannibal-3-app \
+  --deployment-group-name nestjs-hannibal-3-dg \
+  --max-items 5 \
+  --region ap-northeast-1
+
+aws deploy get-deployment \
+  --deployment-id <deployment-id> \
+  --region ap-northeast-1
+```
+
+### 手動 rollback
+
+自動 rollback が進まない、または利用者影響が継続している場合は、進行中 deployment を止める。
+
+```bash
+aws deploy stop-deployment \
+  --deployment-id <deployment-id> \
+  --auto-rollback-enabled \
+  --region ap-northeast-1
+```
+
+前バージョンを明示的に戻す必要がある場合は、前回成功した task definition または AppSpec を使って再 deployment する。
+GitHub Actions 由来の変更なら、原因 commit を revert して PR 経由で戻す。
+
+```bash
+git revert <commit-sha>
+git push origin <branch>
+```
+
+rollback 後は次を確認する。
+
+- CodeDeploy deployment が `Succeeded` になっている
+- ECS service の `runningCount` が `desiredCount` と一致している
+- ALB 5xx が止まっている
+- `TargetResponseTime` が SLO 範囲に戻っている
+- ECS logs に同じ error が出続けていない
+
+## 復旧後
+
+1. 発生時刻、検知した alarm、利用者影響、原因、暫定対応、恒久対応を Issue または PR に記録する。
+2. 同じ alarm が繰り返される場合は、閾値調整ではなく先に原因を調査する。
+3. Terraform / workflow / script の変更が必要な場合は、通常の Issue -> Branch -> PR の流れで対応する。

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -126,6 +126,21 @@ aws ecs describe-tasks \
 4. canary 中の 5xx であれば auto rollback を待つ。止まらない場合は手動停止する。
 
 ```bash
+for tg in nestjs-hannibal-3-blue-tg nestjs-hannibal-3-green-tg; do
+  TG_ARN=$(aws elbv2 describe-target-groups \
+    --names "$tg" \
+    --query 'TargetGroups[0].TargetGroupArn' \
+    --output text \
+    --region ap-northeast-1 2>/dev/null) || continue
+  echo "=== $tg ==="
+  aws elbv2 describe-target-health \
+    --target-group-arn "$TG_ARN" \
+    --query 'TargetHealthDescriptions[*].{Target:Target.Id,State:TargetHealth.State,Reason:TargetHealth.Reason}' \
+    --region ap-northeast-1
+done
+```
+
+```bash
 aws deploy list-deployments \
   --application-name nestjs-hannibal-3-app \
   --deployment-group-name nestjs-hannibal-3-dg \

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -1,0 +1,78 @@
+# SLO - NestJS Hannibal 3
+
+この文書は、`nestjs-hannibal-3` を起動している間の最小限の SLO
+（Service Level Objective）を定義する。
+
+このプロジェクトの dev 環境はコスト抑制のため、通常 destroy 済みで運用する。
+そのため、ここでの SLO は「サービスを利用可能な状態として deploy / provisioning している期間」を対象にする。
+計画的な destroy、Terraform apply 中の切替時間、明示的なメンテナンス時間は SLO 対象外とする。
+
+## 対象サービス
+
+| 項目       | 対象                                                            |
+| ---------- | --------------------------------------------------------------- |
+| Public API | `https://api.hamilcar-hannibal.click` 配下の ALB 経由リクエスト |
+| Frontend   | CloudFront + S3 で配信する React client                         |
+| Backend    | ECS Fargate 上の NestJS API                                     |
+| Database   | RDS PostgreSQL                                                  |
+
+まずは ALB / ECS / RDS の CloudWatch メトリクスで利用者影響を判断する。
+アプリケーション固有の詳細メトリクスは、必要になった時点で追加する。
+
+## Service Level Indicators
+
+| SLI              | CloudWatch で見るもの                                                    | 判定の考え方                                                                         |
+| ---------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| レスポンスタイム | `AWS/ApplicationELB` の `TargetResponseTime`                             | ALB から ECS target までの平均応答時間を見る                                         |
+| エラー率         | `AWS/ApplicationELB` の `HTTPCode_Target_5XX_Count` と HTTP status count | 5xx をサーバ側エラーとして扱う。4xx は原則として利用者入力や認証由来として分ける     |
+| 稼働率           | ECS `RunningTaskCount`、ALB target health、CodeDeploy status             | 起動期間中に少なくとも期待する ECS task が healthy target として応答しているかを見る |
+| デプロイ健全性   | CodeDeploy deployment status、canary 用 CloudWatch Alarm                 | canary / bluegreen の切替中に 5xx と応答時間が悪化していないかを見る                 |
+
+## SLO
+
+| 項目             | 目標                                                                                                         | 既存アラートとの関係                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| レスポンスタイム | 起動期間中の 5分平均 `TargetResponseTime` を 1秒未満に保つ。通常時の運用目安は 200ms 未満                    | `nestjs-hannibal-3-alb-response-time-high` が 1秒超過を 2期間連続で検知する                                          |
+| エラー率         | 起動期間中の target 5xx rate を 0.1% 未満に保つ。低トラフィック時は 5分あたり 5件以上の 5xx を調査対象にする | `nestjs-hannibal-3-alb-5xx-error-rate-high` が 5分合計 5件超過を検知する                                             |
+| 稼働率           | 起動期間中の月次可用性 99.5% 以上を目標にする                                                                | ECS task 停止、ALB 5xx、CodeDeploy 失敗を利用者影響のシグナルとして扱う                                              |
+| Canary 安全性    | canary 中は 1分単位で 5xx と応答時間を監視し、悪化時は CodeDeploy の auto rollback を優先する                | `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time` を CodeDeploy alarm として利用する |
+
+## 計測方法
+
+CloudWatch Dashboard は Terraform の `module.monitoring` で作成する。
+まず次を確認する。
+
+- Dashboard: `hannibal-system-dashboard`
+- ECS: `CPUUtilization`, `MemoryUtilization`, `RunningTaskCount`
+- RDS: `CPUUtilization`, `DatabaseConnections`
+- ALB: `TargetResponseTime`, `HTTPCode_Target_2XX_Count`, `HTTPCode_Target_4XX_Count`, `HTTPCode_Target_5XX_Count`
+- Logs: `/ecs/nestjs-hannibal-3-api-task`
+
+CLI で確認する場合の例:
+
+```bash
+aws cloudwatch describe-alarms \
+  --alarm-name-prefix nestjs-hannibal-3 \
+  --region ap-northeast-1
+
+aws ecs describe-services \
+  --cluster nestjs-hannibal-3-cluster \
+  --services nestjs-hannibal-3-api-service \
+  --region ap-northeast-1
+
+aws logs tail /ecs/nestjs-hannibal-3-api-task \
+  --since 30m \
+  --region ap-northeast-1
+```
+
+## エラーバジェット
+
+dev 中心のポートフォリオ運用では、厳密な SLA ではなく改善判断の材料として扱う。
+月次で次のどれかに当てはまる場合は、運用改善 Issue を作る。
+
+- 起動期間中の可用性が 99.5% を下回った
+- `TargetResponseTime` 1秒超過が複数回発生した
+- 5xx が同じ原因で繰り返し発生した
+- canary / bluegreen deployment の rollback が発生した
+
+改善 Issue では、原因、利用者影響、暫定対応、恒久対応を記録する。

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -34,8 +34,8 @@
 | ---------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | レスポンスタイム | 起動期間中の 5分平均 `TargetResponseTime` を 1秒未満に保つ。通常時の運用目安は 200ms 未満                    | `nestjs-hannibal-3-alb-response-time-high` が 1秒超過を 2期間連続で検知する                                          |
 | エラー率         | 起動期間中の target 5xx rate を 0.1% 未満に保つ。低トラフィック時は 5分あたり 5件以上の 5xx を調査対象にする | `nestjs-hannibal-3-alb-5xx-error-rate-high` が 5分合計 5件超過を検知する                                             |
-| 稼働率           | 起動期間中の月次可用性 99.5% 以上を目標にする                                                                | ECS task 停止、ALB 5xx、CodeDeploy 失敗を利用者影響のシグナルとして扱う                                              |
-| Canary 安全性    | canary 中は 1分単位で 5xx と応答時間を監視し、悪化時は CodeDeploy の auto rollback を優先する                | `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time` を CodeDeploy alarm として利用する |
+| 稼働率           | 起動期間中の月次可用性 99.5% 以上を目標にする                                                                | `nestjs-hannibal-3-ecs-task-stopped` または `nestjs-hannibal-3-alb-5xx-error-rate-high` が ALARM 状態だった時間の合計を月次停止時間として扱う。本環境は destroy/deploy 運用のため外形監視（CloudWatch Synthetics 等）は導入していない。本番相当環境では Synthetics Canary による black-box 監視を追加する |
+| Canary 安全性    | canary 中は 1分単位で 5xx と応答時間を監視し、悪化時は CodeDeploy の auto rollback を優先する                | `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time` を CodeDeploy alarm として利用する。canary 用応答時間アラームの閾値は 2秒（定常 SLO の 1秒より緩め）。デプロイ時のコンテナ起動・接続プール初期化による一時的な遅延と実際の品質劣化を切り分けるため意図的に乖離させている |
 
 ## 計測方法
 


### PR DESCRIPTION
## 目的（推奨）

SLO と Runbook を最小限でも文書化し、CloudWatch Alarm 発火時に何を見るか、何をもって正常とするかを確認できる状態にする。

## 変更内容（推奨）

- `docs/operations/slo.md` を追加し、レスポンスタイム・エラー率・稼働率の目標と CloudWatch での計測方法を整理
- `docs/operations/runbook.md` を追加し、CloudWatch Alarm ごとの初動、ECS task 停止時の確認、CodeDeploy rollback 手順を整理
- `docs/operations/README.md` に SLO / Runbook へのリンクを追加

## 影響範囲（推奨）

- **対象**: 運用ドキュメント
- **非対象**: Terraform、GitHub Actions、AWS リソース、アプリケーションコード

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし  
**コスト根拠**: docs-only のためコスト影響なし  
**リスク根拠**: docs-only のため低リスク

</details>

## 可観測性/検証 *条件付き*

- `npm run commitlint -- --from main --to HEAD --verbose`
- `npx prettier --check docs/operations/slo.md docs/operations/runbook.md`
- `git diff --check main..HEAD`

## ロールバック *条件付き*

軽運用の docs-only PR のため、必要な場合は本 PR のコミットを revert する。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```text
commitlint: pass
prettier check: pass
git diff --check: pass
```

</details>

## メモ（レビューポイント）

- Issue #274 の受け入れ条件にある SLO 項目と Runbook 項目を満たしているか
- 既存 CloudWatch Alarm / CodeDeploy 設定と矛盾する記載がないか


Closes #274
