### PR TITLE
fix(dockerfile): dev deps が本番イメージに混入する multi-stage build のバグを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,12 @@ RUN apk add --no-cache wget && \
 COPY package*.json ./
 RUN npm ci --omit=dev
 
-# distディレクトリとnode_modulesをコピー
+# コンパイル済み JS
 COPY --from=builder /usr/src/app/dist ./dist
-COPY --from=builder /usr/src/app/src ./src
-COPY --from=builder /usr/src/app/node_modules ./node_modules
+
+# Apollo Server schema-first: typePaths が ./**/*.graphql をランタイムに読む
+# definitions.path が src/graphql/graphql.schema.ts に書き出すためディレクトリも必要
+COPY --from=builder /usr/src/app/src/graphql/schema ./src/graphql/schema
 
 ENV NODE_ENV=production
 ENV PORT=3000


### PR DESCRIPTION
## 目的（推奨）

`COPY --from=builder .../node_modules` が `npm ci --omit=dev` の結果を上書きしており、TypeScript コンパイラ・Jest・ESLint などの dev dependencies が本番イメージに混入していた。dev deps を除去してイメージサイズと攻撃面を削減する。

## 変更内容（推奨）

`Dockerfile` の production stage から `COPY --from=builder .../node_modules` を削除し、`src` 全体のコピーを Apollo schema-first に必要な `.graphql` ファイルのみに絞る。

## 影響範囲（推奨）

- **対象**: `Dockerfile`
- **非対象**: Terraform、GitHub Actions workflow、アプリケーションコード

## PRラベル（必須）

- **type**: `type:bug`
- **area**: `area:backend`
- **risk**: `risk:medium`
- **cost**: `cost:none`

## 可観測性/検証

PR CI の `Docker Build` job および `Verify non-root user` が通過することで確認。

## ロールバック

`git revert <this-commit>` で本 PR のコミットを戻し、push → deploy。`Dockerfile` のみの変更のため Terraform apply は不要。

## リリース連携（推奨）

- **リリースノート**: 不要

Closes #284