### PR TITLE
docs: ops ドキュメントの古い IAM 権限数値を設計方針の説明に修正する

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -23,8 +23,8 @@
 - **環境分離**: `terraform/environments/dev/` で管理
 
 ### 2. 最小権限原則
-- **IAM最適化**: 160権限 → 76権限 (47.5%削減達成)
-- **Permission Boundary**: HannibalCICDBoundary で上限設定
+- **IAM設計**: role 分離・write/exec action 列挙・read 系プレフィックス wildcard・Permission Boundary による最小権限設計（#164, #293）
+- **Permission Boundary**: 全 Hannibal 系 Role に専用 Boundary を付与し最大権限を制限
 - **AssumeRole**: 一時的な権限昇格のみ
 
 ### 3. 監査性・トレーサビリティ

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -19,7 +19,7 @@ graph TB
         CloudTrail[CloudTrail<br/>API Call Logs]
         S3_Logs[S3 Bucket<br/>nestjs-hannibal-3-cloudtrail-logs]
         Athena_DB[Athena Database<br/>hannibal_cloudtrail_db]
-        Analysis[Permission Analysis<br/>76/160 Permissions Used]
+        Analysis[Permission Analysis<br/>CloudTrail + Athena]
         
         CloudTrail --> S3_Logs
         S3_Logs --> Athena_DB
@@ -56,10 +56,10 @@ graph TB
 
 CloudTrailログからCI/CD権限の実際の使用状況を分析し、最小権限の原則に基づいた権限最適化を実施します。
 
-### **分析結果**
-- **現在のポリシー**: 160ちょいの権限
+### **分析例（2025年7月27日時点）**
+- **分析時点のポリシー**: 160権限
 - **実際に使用**: **76個の権限**（2025年7月27日15-20時JST分析）
-- **削減可能**: 約52%の権限削減が可能
+- この分析を起点に最小権限化を進め、#164 / #293 で設計を確定済み
 
 ### **企業レベル分析手順**
 ```bash


### PR DESCRIPTION
## 目的（推奨）
#293 完了後も `docs/operations/README.md` と `docs/operations/monitoring.md` に旧分析（2025年7月）の古い数字が残っており、現状の設計を誤読させるため修正する。

## 変更内容（推奨）
- `README.md`: 「160権限→76権限(47.5%削減達成)」を role 分離・write/exec 列挙・Permission Boundary の設計方針説明に書き換え
- `monitoring.md`: mermaid 図の「76/160 Permissions Used」を「CloudTrail + Athena」に変更
- `monitoring.md`: 「現在のポリシー/削減可能」フレームを「2025年7月27日時点の分析例」として歴史的記録に変更（Athena クエリは維持）

## 影響範囲（推奨）
- **対象**: docs のみ
- **非対象**: Terraform コード・IAM リソース・CI/CD 動作

## 可観測性/検証 *条件付き*
No-op（適用外）

## ロールバック *条件付き*
不要（docs のみ）

## リリース連携（推奨）
- **リリースノート**: 不要

Closes #295