### PR TITLE
docs: GitHub FlowモデルのADRを追加

### DIFF
--- a/docs/adr/0010-adopt-lightweight-and-strict-github-flow.md
+++ b/docs/adr/0010-adopt-lightweight-and-strict-github-flow.md
@@ -1,0 +1,79 @@
+# 0010. 軽運用 / 厳密運用を分ける GitHub Flow モデルを採用する
+
+## ステータス
+
+Accepted
+
+## 日付
+
+2026-06-01
+
+## 決定内容
+
+`terraform-hannibal` では、Issue -> Branch -> PR -> Merge を基本としつつ、変更内容に応じて軽運用と厳密運用を分ける GitHub Flow モデルを採用する。
+
+共通の必須条件として、Issue / PR には `type / area / risk / cost` ラベルを付け、PR には `Closes / Fixes / Refs #<issue番号>` のいずれかを記載する。`main` への direct push は避け、PR と required status checks を通してから squash merge する。
+
+軽運用では、Issue / PR 本文を最小限に保ち、Issue リンク、必須ラベル、CI によって最低限の構造と品質を担保する。厳密運用では、`risk:medium/high`、`cost:medium/large`、`terraform/**`、`.github/workflows/**`、IAM / OIDC / deploy / destroy / Security などの影響範囲を基準に、PR 本文のロールバック手順を必須にする。
+
+AI Agent / CLI / API からの起票や PR 作成も許容するが、Issue 作成前、ブランチ作成後の実装前、PR 作成前には人間が確認する計画提示を挟む。Issue / PR の正規作成経路は既存 helper を使い、最終的な形式チェックは GitHub Actions に任せる。
+
+なお、運用ルールの正本は `CONTRIBUTING.md` とし、本 ADR はその判断理由を記録する履歴として扱う。設計意図、未採用案、将来の再検討条件は `docs/operations/github-flow-guardrails.md` に置く。
+
+## 背景
+
+このプロジェクトは少人数・dev 中心で運用するポートフォリオ用インフラである。一方で、Terraform、GitHub Actions、IAM / OIDC、deploy / destroy といった変更は、誤ると環境破壊や権限過多につながる。
+
+すべての変更に重い承認や本文チェックを求めると、軽微な docs / CI 整理や AI Agent を使った小さな作業まで過剰に重くなる。逆に、Issue リンク、ラベル、CI、ロールバック条件を緩めすぎると、AI Agent / CLI / API からの作業で意図や影響範囲が追跡しづらくなる。
+
+そのため、軽微な変更は軽く流せる余地を残しながら、Terraform / workflow / IAM / deploy / destroy / Security などの変更では厳密な確認が働くモデルが必要になった。
+
+## 検討した選択肢
+
+### 軽運用 / 厳密運用を分ける GitHub Flow（採択）
+
+- 長所: 軽微な変更の速度を保ちつつ、リスクの高い変更ではロールバックや影響範囲の確認を厚くできる
+- 長所: AI Agent / CLI / API の利用を前提にしても、Issue リンク、ラベル、CI、事前計画確認で品質を揃えやすい
+- 短所: 軽運用か厳密運用かの判断を、ラベル、変更対象、変更内容から毎回確認する必要がある
+
+### approval を常時必須にする
+
+- 長所: すべての PR に人間レビューの明示的なゲートを置ける
+- 短所: 少人数運用では重く、形式的な承認になりやすい
+
+### CODEOWNERS を即導入する
+
+- 長所: 領域ごとのレビュー責任を GitHub 上で明示できる
+- 短所: 現状は責任分担の実益が薄く、少人数では運用コストが先に立つ
+
+### dev Environment 承認を deploy / destroy に付ける
+
+- 長所: deploy / destroy の実行前に追加の承認ゲートを置ける
+- 短所: `deploy.yml` は手動実行であり、`destroy.yml` も `workflow_dispatch + DESTROY` 入力で強い確認を持っているため、dev 中心運用では二重承認になりやすい
+
+### 全 PR で重い本文チェックを必須にする
+
+- 長所: すべての PR 本文の粒度を揃えられる
+- 短所: 軽微な docs / CI 修正にも過剰で、必要なゲートである Issue リンク、必須ラベル、CI より本文形式の負担が目立ちやすい
+
+## 採択理由
+
+少人数・dev 中心運用では、すべての変更を重い承認フローへ寄せるよりも、リスクに応じて確認の厚さを変える方が実効性が高い。
+
+軽運用でも Issue、ラベル、PR、CI は必須にするため、最低限の追跡性と品質ゲートは残る。厳密運用では、ロールバック手順や影響範囲の明示を求めることで、Terraform、workflow、IAM、deploy / destroy、Security などの変更をより丁寧に扱える。
+
+AI Agent を使う前提でも、Issue 作成前、実装前、PR 作成前に計画を提示して人間が確認する流れにすると、作業を完全停止させずに意図のズレを早い段階で直せる。最終的な形式チェックは GitHub Actions に寄せることで、人間は判断の質に集中しやすくなる。
+
+## 影響
+
+- 軽微な docs / chore / test 変更は、必要な構造を保ちながら軽く進められる
+- Terraform、workflow、IAM / OIDC、deploy / destroy、Security などの変更は厳密運用として扱い、PR 本文に実効性のあるロールバック手順が必要になる
+- Issue / PR の品質は、事前計画、人間確認、helper、GitHub Actions の組み合わせで担保する
+- 将来、常時レビュー担当が複数名いる体制、本番相当の継続運用、領域オーナーの明確化が進んだ場合は、approval 必須化、CODEOWNERS、Environment 承認を再検討する
+
+## 関連
+
+- [Issue #301](https://github.com/kmryst/terraform-hannibal/issues/301)
+- [Issue #297](https://github.com/kmryst/terraform-hannibal/issues/297)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Issue / Branch / Commit / PR / Label / 軽運用・厳密運用の正本
+- [GitHub Flow Guardrails](../operations/github-flow-guardrails.md) - 設計意図、未採用案、将来の再検討条件

--- a/docs/adr/0010-adopt-lightweight-and-strict-github-flow.md
+++ b/docs/adr/0010-adopt-lightweight-and-strict-github-flow.md
@@ -12,13 +12,15 @@ Accepted
 
 `terraform-hannibal` では、Issue -> Branch -> PR -> Merge を基本としつつ、変更内容に応じて軽運用と厳密運用を分ける GitHub Flow モデルを採用する。
 
-共通の必須条件として、Issue / PR には `type / area / risk / cost` ラベルを付け、PR には `Closes / Fixes / Refs #<issue番号>` のいずれかを記載する。`main` への direct push は避け、PR と required status checks を通してから squash merge する。
+判断の核は次の 3 点である。
 
-軽運用では、Issue / PR 本文を最小限に保ち、Issue リンク、必須ラベル、CI によって最低限の構造と品質を担保する。厳密運用では、`risk:medium/high`、`cost:medium/large`、`terraform/**`、`.github/workflows/**`、IAM / OIDC / deploy / destroy / Security などの影響範囲を基準に、PR 本文のロールバック手順を必須にする。
+- すべての変更に共通の最低限のゲート（Issue リンク、必須ラベル、PR、required status checks）を課す
+- 軽微な変更（軽運用）は Issue / PR 本文を最小限に保ち、速度を落とさない
+- リスクの高い変更（厳密運用）はロールバック手順と影響範囲の明示を求め、確認を厚くする
 
-AI Agent / CLI / API からの起票や PR 作成も許容するが、Issue 作成前、ブランチ作成後の実装前、PR 作成前には人間が確認する計画提示を挟む。Issue / PR の正規作成経路は既存 helper を使い、最終的な形式チェックは GitHub Actions に任せる。
+`main` への direct push は branch protection で禁止し、PR と required status checks を通したうえで squash merge する。AI Agent / CLI / API からの起票や PR 作成も許容するが、Issue 作成前・ブランチ作成後の実装前・PR 作成前に人間が確認する計画提示を挟み、最終的な形式チェックは GitHub Actions に委ねる。
 
-なお、運用ルールの正本は `CONTRIBUTING.md` とし、本 ADR はその判断理由を記録する履歴として扱う。設計意図、未採用案、将来の再検討条件は `docs/operations/github-flow-guardrails.md` に置く。
+運用ルールの具体（必須ラベルの種類、`Closes / Fixes / Refs` の記法、軽運用 / 厳密運用に該当する変更の判定基準など）の正本は `CONTRIBUTING.md` とする。本 ADR はその具体を再掲せず、なぜこのモデルにしたかの判断理由を記録する履歴として扱う。設計意図、未採用案、将来の再検討条件は `docs/operations/github-flow-guardrails.md` に置く。
 
 ## 背景
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@
 | [0007](./0007-remove-unused-access-analyzer-permissions.md) | Accepted | 未使用の Access Analyzer / IAM read 権限を CICD Role から削除する |
 | [0008](./0008-on-demand-startup-and-routine-destroy-operation.md) | Accepted | オンデマンド起動 / 通常 destroy 運用を採用する（コスト系判断の親前提） |
 | [0009](./0009-keep-nestjs-hannibal-3-resource-names.md) | Accepted | 既存の AWS リソース名 nestjs-hannibal-3-* をリネームしない |
+| [0010](./0010-adopt-lightweight-and-strict-github-flow.md) | Accepted | 軽運用 / 厳密運用を分ける GitHub Flow モデルを採用する |


### PR DESCRIPTION
## 目的（推奨）

軽運用 / 厳密運用を分ける GitHub Flow モデルについて、採用理由・未採用案・再検討条件を ADR として追跡できるようにする。

## 変更内容（推奨）

- `docs/adr/0010-adopt-lightweight-and-strict-github-flow.md` を追加
- `docs/adr/README.md` の ADR 一覧に `0010` を追記

## 影響範囲（推奨）

- **対象**: ADR ドキュメント、ADR 一覧
- **非対象**: Terraform、GitHub Actions workflow、scripts、アプリケーションコード

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`, `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）: なし
**コスト根拠**（小/中/大の場合）: docs only のためなし
**リスク根拠**（Medium/Highの場合）: low のため該当なし

</details>

## 可観測性/検証 *条件付き*

No-op（適用外）。docs only のため実行時可観測性への影響なし。

検証:

- `git diff --check`
- `npx prettier --check docs/adr/0010-adopt-lightweight-and-strict-github-flow.md`
- `npm run commitlint -- --from main --to HEAD --verbose`
- pre-commit hook: secret scan passed

## ロールバック *条件付き*

軽運用 PR のため必須ではない。必要な場合は本 PR の revert で ADR 追加と README 追記を戻す。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

docs only のためアプリケーションテストは未実行。

</details>

## メモ（レビューポイント）

- ADR は `CONTRIBUTING.md` / `docs/operations/github-flow-guardrails.md` を正本として参照し、運用ルールの重複定義にならないように整理している
- #301 の受け入れ条件である未採用案（approval 常時必須 / CODEOWNERS 即導入 / dev Environment 承認 / 全 PR 重い本文チェック）を選択肢として記載している


Closes #301
