### PR TITLE
ci: add Dependabot config for GitHub Actions weekly version tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -81,6 +81,14 @@ GitHub Actions の Node 20 runtime deprecation と CodeQL Action v3 deprecation 
 Node 20 runtime を使う JS action が残っていれば version 更新または別 action への置換を検討します。
 Docker action / composite action / `actions/setup-node` でインストールしている Node.js 20 自体は、この warning とは別の扱いです。
 
+### action バージョン管理方針
+
+各 workflow の action は `@vX` メジャータグで固定し、Dependabot（`.github/dependabot.yml`）の週次スケジュールによる自動 PR で version drift を追跡します。
+
+メジャータグを使う理由は可読性の維持と GitHub 公式 action のリリース管理が厳格であることです。SHA ピンはサプライチェーンリスクをさらに下げますが、PR の diff が SHA の羅列になるためポートフォリオの文脈では採用しません。
+
+Dependabot が生成した PR は CI（`pr-check.yml`）を通過後にマージします。major version 更新は破壊的変更を含む可能性があるため、リリースノートを確認してからマージします。
+
 ## deploy workflow との役割分担
 
 `deploy.yml` は `workflow_dispatch` による `main` からの手動デプロイに限定する。backend/frontend の build・test は PR gate（`pr-check.yml`）に集約し、deploy workflow では再実行しない。


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）

`.github/workflows/` の action は `@vX` メジャータグで固定されており、新しいリリースへの追跡を手動で行う必要があった。Dependabot を有効化して自動 PR による版管理に切り替える。

## 変更内容（推奨）

- `.github/dependabot.yml` 新規作成（`github-actions` エコシステム、週次月曜 09:00 JST）
- `docs/operations/quality-gates.md` に action バージョン管理方針を追記（メジャータグ + Dependabot 方針、SHA ピンを採用しない理由）

## 影響範囲（推奨）

- **対象**: GitHub Actions の action バージョン追跡（Dependabot PR が週次で自動生成される）
- **非対象**: 既存 workflow の挙動・npm 依存関係

## PRラベル（必須）
- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

No-op（適用外）。Dependabot PR が生成された際に CI（`pr-check.yml`）を通過することで検証される。

## ロールバック *条件付き*

軽運用のため省略。

## リリース連携（推奨）
- **リリースノート**: 不要

## メモ（レビューポイント）

`ecosystem: github-actions` のみ対象。npm の Dependabot は別 Issue で検討する。

Closes #323


Closes #323
