### PR TITLE
ci: add required labels to Dependabot config for PR policy compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    labels:
+      - "type:chore"
+      - "area:ci-cd"
+      - "risk:low"
+      - "cost:none"


### PR DESCRIPTION
## 目的（推奨）

#324 で追加した `dependabot.yml` に `labels:` 設定が抜けていたため、Dependabot が生成した PR #325〜#328 が `PR Policy Check`（必須ラベルチェック）で落ちた。`labels:` を追加して以降の Dependabot PR に自動でラベルが付くようにする。

既存の PR #325〜#328 には手動でラベルを追加済み。

## 変更内容（推奨）

- `.github/dependabot.yml` に `labels: [type:chore, area:ci-cd, risk:low, cost:none]` を追加

## 影響範囲（推奨）

- **対象**: 以降に Dependabot が生成する `github-actions` の PR（自動ラベル付与される）
- **非対象**: 既存 PR・workflow の挙動

## PRラベル（必須）
- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

No-op（適用外）。次回 Dependabot PR 生成時にラベルが自動付与されることで検証される。

## ロールバック *条件付き*

軽運用のため省略。

## リリース連携（推奨）
- **リリースノート**: 不要

Refs #323


Closes #323
