### PR TITLE
ci: skip PR Policy Check for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   pr-policy-check:
     name: PR Policy Check
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 目的（推奨）

Dependabot の自動 PR は Issue 連携・ラベル体系・ロールバック計画（人間のガバナンスルール）の対象外であるにもかかわらず、PR Policy Check が fail していた。`pr-policy-check` ジョブを `dependabot[bot]` でスキップし、技術的品質チェック（lint・test・build 等）は引き続き実行する。

## 変更内容（推奨）

- `.github/workflows/pr-check.yml` の `pr-policy-check` ジョブに `if: github.actor != 'dependabot[bot]'` を追加（1行）

## 影響範囲（推奨）

- **対象**: Dependabot PR の `PR Policy Check`（`skipped` になり required status check を充足）
- **非対象**: 人間が作成した PR の挙動・他のジョブ（lint・test・build 等）

## PRラベル（必須）
- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

既存の Dependabot PR（#325〜#328）で PR Policy Check が `skipped` になり、マージ可能になることで検証する。

## ロールバック *条件付き*

`if: github.actor != 'dependabot[bot]'` の1行を削除するだけで元の挙動に戻る。インフラへの影響なし。

## リリース連携（推奨）
- **リリースノート**: 不要

Closes #332


Closes #332
