### PR TITLE
docs(adr): bootstrap 用 Terraform 別 state 案を ADR 0014 に追記する

### DIFF
--- a/docs/adr/0014-separate-terraform-foundation-and-environment-state.md
+++ b/docs/adr/0014-separate-terraform-foundation-and-environment-state.md
@@ -46,6 +46,13 @@ S3 bucket は共有してよいが、state key は `foundation/terraform.tfstate
 - 長所: `environments/<env>` の追加で将来の環境拡張に対応しやすい
 - 短所: Terraform 実行単位が増え、Role や runbook で「どちらを apply するか」を明示する必要がある
 
+### state backend 自体も Terraform 管理にする（bootstrap 用 root / 別 state を持つ）
+
+- 長所: S3 state bucket / DynamoDB lock table も IaC で再現でき、初期構築手順の drift を減らせる
+- 短所: bootstrap の state をどこに置くかが再帰し、local state か「同一 bucket + `prevent_destroy`」などの追加対策が必要になる
+- 短所: 誤 destroy / state 破損時の復旧コストが最大級の backend を、Terraform 実行経路に乗せることになる
+- 短所: 少人数・dev 中心運用では、bootstrap を IaC 化して得られる再現性の利点が薄い
+
 ## 採択理由
 
 foundation と environments では、保持すべき期間、変更頻度、必要な権限、レビュー観点が異なる。
@@ -55,6 +62,8 @@ foundation は環境を作るための土台であり、日常の deploy / destr
 一方で、`terraform/environments/dev` はアプリケーション環境の再作成・破棄を前提にした実行単位であり、dev 固有のオンデマンド運用と相性がよい。state key を環境ごとに分けることで、dev の destroy や将来の prod apply が他の環境 state と競合しない。
 
 同じ S3 bucket を共有しつつ key を分ける構成は、管理対象を増やしすぎずに state 境界を確保できる。state locking の方式自体は ADR 0003 の判断に従い、S3 lockfile を正とする。
+
+state backend 自体を Terraform 管理にする案は、bootstrap state の置き場所が再帰し、復旧コストの高い backend を Terraform 実行経路に乗せる短所が、再現性の利点を上回るため採らない。state backend は `manual-resources.md` の手動管理リソースとして維持する。
 
 ## 影響
 
@@ -72,6 +81,7 @@ foundation は環境を作るための土台であり、日常の deploy / destr
 - [ADR 0005: deploy/destroy 用 Role と PR plan 用 Role を分離する](./0005-separate-cicd-and-pr-plan-roles.md)
 - [ADR 0008: オンデマンド起動 / 通常 destroy 運用を採用する](./0008-on-demand-startup-and-routine-destroy-operation.md)
 - [Terraform 環境分離設計](../terraform-environments.md)
+- [手動管理 AWS リソース一覧](../operations/manual-resources.md)
 - [IAM権限管理](../operations/iam-management.md)
 - [terraform/foundation/backend.tf](../../terraform/foundation/backend.tf)
 - [terraform/environments/dev/backend.tf](../../terraform/environments/dev/backend.tf)


### PR DESCRIPTION
## 目的（推奨）

#303 の ADR 候補補強。ADR 0014 の「検討した選択肢」に state backend を Terraform 管理にする（bootstrap 用 root / 別 state を持つ）案が無く、「検討して手動を選んだ」記録が弱かったため追記する。

## 変更内容（推奨）

- ADR 0014 の「検討した選択肢」に bootstrap 用 Terraform 別 state 案を追加
- 「採択理由」に不採用理由（bootstrap state の再帰・backend 復旧コスト）を明記
- 「関連」に `docs/operations/manual-resources.md` リンクを追加

## 影響範囲（推奨）

- **対象**: `docs/adr/0014-separate-terraform-foundation-and-environment-state.md`
- **非対象**: Terraform 実体、AWS リソース、GitHub Actions workflow、IAM 権限

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`, `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

No-op（docs-only）

- ローカル Markdown リンク確認: OK
- whitespace check: OK

## ロールバック *条件付き*

軽運用の docs-only PR のため必須ではない。必要な場合は本 PR の commit を revert する。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

#303 は複数 ADR 候補を管理するバックログ Issue のため、本 PR では自動 close せず `Refs #303` とする。実装結論は「現状維持（手動管理）」であり、Terraform 実体の変更は無い。

Refs #303


Refs #303