### PR TITLE
docs: アーキテクチャドキュメントの記述を整理する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -413,7 +413,7 @@ terraform plan -out=tfplan
 
 **通常稼働時**: 月額 $30-50
 - ECS Fargate: 0.25vCPU / 0.5GB ($15-20)
-- RDS t4g.micro: ($10-15)
+- RDS db.t3.micro: ($10-15)
 - ALB: ($18)
 - NAT Gateway: ($32)
 

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -86,7 +86,7 @@ type Query {
 
 ### 水平スケーリング（実装済み）
 - **ECS Fargate**: 0.25vCPU / 0.5GB メモリ（コスト最適化構成）
-- **RDS**: PostgreSQL 15 - t4g.micro（Single-AZ、コスト重視）
+- **RDS**: PostgreSQL 15 - db.t3.micro（Single-AZ、コスト重視）
 - **CloudFront**: グローバルCDN配信
 
 ### パフォーマンス最適化（実装済み）
@@ -167,7 +167,7 @@ type Query {
 ### 停止運用による大幅削減
 - **通常稼働時**: 月額 $30-50
   - ECS Fargate: 0.25vCPU / 0.5GB ($15-20)
-  - RDS t4g.micro ($10-15)
+  - RDS db.t3.micro ($10-15)
   - ALB ($18)
   - NAT Gateway ($32)
 - **停止時**: 月額 $5以下

--- a/docs/architecture/terraform-modules.md
+++ b/docs/architecture/terraform-modules.md
@@ -23,7 +23,7 @@ terraform/
 │   ├── cicd/
 │   │   └── codedeploy/     # CodeDeploy (Blue/Green + Canary)
 │   ├── storage/
-│   │   ├── rds/            # PostgreSQL 15 (t4g.micro)
+│   │   ├── rds/            # PostgreSQL 15 (db.t3.micro)
 │   │   └── s3/             # Static Assets + Artifacts
 │   ├── cdn/
 │   │   └── cloudfront/     # CloudFront (グローバルCDN)
@@ -155,7 +155,7 @@ module "rds" {
   engine_version = "15"
   
   # コスト最適化構成（dev環境）
-  instance_class = "db.t4g.micro"
+  instance_class = "db.t3.micro"
   allocated_storage = 20
   
   # Single-AZ（コスト重視）
@@ -330,7 +330,7 @@ graph TD
 | **compute** | ecs | ✅ | Fargate 0.25vCPU / 0.5GB |
 | | load-balancer | ✅ | ALB (Blue/Green対応) |
 | **cicd** | codedeploy | ✅ | Blue/Green + Canary |
-| **storage** | rds | ✅ | PostgreSQL 15 (t4g.micro) |
+| **storage** | rds | ✅ | PostgreSQL 15 (db.t3.micro) |
 | | s3 | ✅ | Static Assets + Artifacts |
 | **cdn** | cloudfront | ✅ | グローバルCDN |
 | **security** | iam | ✅ | Permission Boundary |
@@ -345,26 +345,6 @@ graph TD
 4. **可用性**: Multi-AZ対応可能（現在はコスト重視でSingle-AZ）
 
 ## 品質保証
-
-### モジュールテスト
-```hcl
-# tests/network_test.go
-func TestNetworkModule(t *testing.T) {
-    terraformOptions := &terraform.Options{
-        TerraformDir: "../modules/network",
-        Vars: map[string]interface{}{
-            "project_name": "test-hannibal",
-            "vpc_cidr":     "10.0.0.0/16",
-        },
-    }
-    
-    defer terraform.Destroy(t, terraformOptions)
-    terraform.InitAndApply(t, terraformOptions)
-    
-    vpcId := terraform.Output(t, terraformOptions, "vpc_id")
-    assert.NotEmpty(t, vpcId)
-}
-```
 
 ### バリデーション
 ```hcl
@@ -445,7 +425,7 @@ module "compute" {
 module "storage" {
   source = "../../modules/storage/rds"
   
-  instance_class = "db.t4g.micro"
+  instance_class = "db.t3.micro"
   multi_az       = false  # Single-AZ
 }
 ```

--- a/docs/architecture/terraform-modules.md
+++ b/docs/architecture/terraform-modules.md
@@ -155,7 +155,7 @@ module "rds" {
   engine_version = "15"
   
   # コスト最適化構成（dev環境）
-  instance_class = "db.t3.micro"
+  db_instance_class = "db.t3.micro"
   allocated_storage = 20
   
   # Single-AZ（コスト重視）
@@ -425,8 +425,8 @@ module "compute" {
 module "storage" {
   source = "../../modules/storage/rds"
   
-  instance_class = "db.t3.micro"
-  multi_az       = false  # Single-AZ
+  db_instance_class = "db.t3.micro"
+  multi_az          = false  # Single-AZ
 }
 ```
 


### PR DESCRIPTION
## 目的

アーキテクチャドキュメントの記述を現在の実装に合わせて整理する。

## 変更内容

- `docs/architecture/system-design.md`: RDS インスタンスタイプを `t4g.micro` → `db.t3.micro` に修正
- `docs/architecture/terraform-modules.md`: 同上（ツリー図・コード例・モジュール一覧）、存在しないテストコード（`tests/network_test.go`）の記述を削除
- `.github/copilot-instructions.md`: 同上

## 影響範囲

- **対象**: `docs/architecture/`, `.github/copilot-instructions.md`（docs-only）
- **非対象**: `terraform/**`, アプリ実装, AWS リソース（変更なし・コスト発生なし）

## PRラベル

- **type**: `type:docs`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証

No-op（適用外）。docs-only のため AWS リソース・workflow への影響なし。

## ロールバック

軽運用 PR のため必須ではない。戻す場合は本 PR を revert すれば docs のみ元に戻る。

## リリース連携

- **リリースノート**: 不要

Closes #345


Closes #345
