### PR TITLE
fix(graphql): GraphQL definitions.path書き出しを開発時のみに限定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN npm ci --omit=dev
 COPY --from=builder /usr/src/app/dist ./dist
 
 # Apollo Server schema-first: typePaths が ./**/*.graphql をランタイムに読む
-# definitions.path が src/graphql/graphql.schema.ts に書き出すためディレクトリも必要
 COPY --from=builder /usr/src/app/src/graphql/schema ./src/graphql/schema
 
 ENV NODE_ENV=production

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,9 +18,13 @@ export function createGraphqlOptions(nodeEnv: string): ApolloDriverConfig {
     driver: ApolloDriver,
     typePaths: ['./**/*.graphql'],
     path: '/graphql',
-    definitions: {
-      path: join(process.cwd(), 'src/graphql/graphql.schema.ts'),
-    },
+    // definitions.path はスキーマからTS型を生成する開発用機能。
+    // 本番イメージではsrc/がread-onlyでEACCESになるため開発時のみ有効化する。
+    ...(isDevelopment && {
+      definitions: {
+        path: join(process.cwd(), 'src/graphql/graphql.schema.ts'),
+      },
+    }),
     context: ({ req }) => ({ req }),
     csrfPrevention: true,
     graphiql: isDevelopment,


### PR DESCRIPTION
## Summary
- PR #372(NestJS 11 / Apollo Server 5移行)後、dev環境のECSタスクが起動直後に `EACCES: permission denied, open '/usr/src/app/src/graphql/graphql.schema.ts'` でクラッシュループし、`/graphql` が503になる障害が発生していた。
- `definitions.path` はスキーマからTS型を生成する開発用機能。本番ビルドでは不要かつ `src/` がread-onlyのため書き込みに失敗していた。`isDevelopment` のときのみ有効化するよう修正。
- Dockerfileの古いコメント(definitions.path書き出し用ディレクトリが必要、という記述)を削除。

## Incident
- dev環境(`https://hamilcar-hannibal.click/graphql`)が503エラーとなっていたため、緊急ホットフィックスとして対応。
- revision 425へのロールバックも検討したが、RDS管理シークレットが既にローテーションされており(`rds!db-a4e7d156-...`が失効)起動不可のため断念し、本修正をfix-forwardで適用。
- 再発防止の構造的対応は #378 で別途追跡する。

### 手動デプロイの記録(追跡性のため)
- 復旧を優先し、`deploy.yml`(GitHub Actions)を待たずCLIから直接操作した。**このデプロイはGitHub Actionsの実行履歴には残らない**。
  - 本コミット(3b21c0c)のイメージをビルドし、ECRへpush
  - revision 427(現行の正しいSecrets Manager参照)をベースに、imageのみ本イメージへ差し替えてタスク定義 revision 428 を `aws ecs register-task-definition` で登録
  - `aws deploy create-deployment` でCodeDeploy Blue/Greenデプロイ(deployment ID: `d-DRMDQSENJ`)を実行し、revision 428へ切替
- 本PRがマージされ次回`deploy.yml`が実行されると、同じコードでrevision 429相当が新規登録される想定(競合なし)。

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功
- [x] `npx eslint src/app.module.ts` 通過
- [x] 本修正イメージ(revision 428)をCodeDeploy Blue/Greenでデプロイし、Succeeded。`/graphql`が200で安定稼働することを確認済み(10/10)

## ロールバック
- CodeDeploy Blue/Greenデプロイのため、異常時はCodeDeployコンソール/CLIで直前のタスク定義リビジョンへの再デプロイで切り戻す。
- 今回の修正自体はコードのみの変更(definitions.pathの有効化条件追加)で、Dockerfile・インフラ構成は変更していないため、切り戻しによる副作用はない。

Closes #379
Refs #378