### PR TITLE
ci: deploy/destroy workflow を state 分割後の全 root module 順序に対応させる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,27 @@ jobs:
           npm ci
           npm run build
 
-      # TODO: #398 で network → database → service → cdn の順序 apply に対応する
+      - name: Deploy Infrastructure (network)
+        working-directory: ./terraform/network
+        run: |
+          set -e
+          terraform init -input=false
+          terraform plan \
+            -var="environment=dev" \
+            -out=tfplan
+          terraform apply -auto-approve tfplan
+
+      - name: Deploy Infrastructure (database)
+        working-directory: ./terraform/database
+        run: |
+          set -e
+          terraform init -input=false
+          terraform plan \
+            -var="environment=dev" \
+            -var="db_name=nestjs_hannibal_db" \
+            -out=tfplan
+          terraform apply -auto-approve tfplan
+
       - name: Deploy Infrastructure (service)
         working-directory: ./terraform/service
         run: |
@@ -103,7 +123,7 @@ jobs:
             -var="enable_cloudfront=true" \
             -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
             -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
-            -var="alb_origin_verify_header_value=$(cd ../terraform/service && terraform output -raw alb_origin_verify_header_value 2>/dev/null || echo 'placeholder')" \
+            -var="alb_origin_verify_header_value=$(cd ../service && terraform output -raw alb_origin_verify_header_value 2>/dev/null || echo 'placeholder')" \
             -out=tfplan
           terraform apply -auto-approve tfplan
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -78,7 +78,17 @@ jobs:
           aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE" || true
           echo "✅ ECS service scaled down or stable"
 
-      # TODO: #398 で cdn → service → database → network の逆順 destroy に対応する
+      - name: Destroy Infrastructure (cdn)
+        working-directory: ./terraform/cdn
+        run: |
+          set -e
+          terraform init -input=false
+          terraform destroy -auto-approve \
+            -var="enable_cloudfront=true" \
+            -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
+            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
+            -var="alb_origin_verify_header_value=placeholder-for-destroy"
+
       - name: Destroy Infrastructure (service)
         working-directory: ./terraform/service
         run: |
@@ -91,6 +101,23 @@ jobs:
             -var="ecr_repository_url=${{ vars.ECR_REPOSITORY_URL }}" \
             -var="alb_certificate_arn=${{ vars.ALB_CERTIFICATE_ARN }}" \
             -var="db_name=nestjs_hannibal_db"
+
+      - name: Destroy Infrastructure (database)
+        working-directory: ./terraform/database
+        run: |
+          set -e
+          terraform init -input=false
+          terraform destroy -auto-approve \
+            -var="environment=dev" \
+            -var="db_name=nestjs_hannibal_db"
+
+      - name: Destroy Infrastructure (network)
+        working-directory: ./terraform/network
+        run: |
+          set -e
+          terraform init -input=false
+          terraform destroy -auto-approve \
+            -var="environment=dev"
 
       - name: Cleanup S3 buckets (best-effort)
         run: |
@@ -135,5 +162,5 @@ jobs:
           echo "✅ Destroy workflow completed."
           echo "- CodeDeploy deployments stopped"
           echo "- ECS service scaled down and waited stable"
-          echo "- Terraform destroy (backend -> frontend) executed"
+          echo "- Terraform destroy (cdn → service → database → network) executed"
           echo "- Best-effort cleanup for S3/ECR/ELB/TG finished"


### PR DESCRIPTION
## 目的

state 分割後の 4 root module 構成に合わせて、deploy/destroy workflow の apply/destroy 順序を実装する。

## 変更内容

- `deploy.yml`: network → database ステップを追加（既存の service → cdn の前）
- `destroy.yml`: cdn → service → database → network の逆順 destroy を実装
- TODO コメント削除

## 影響範囲

- **対象**: `.github/workflows/deploy.yml`, `.github/workflows/destroy.yml`
- **非対象**: pr-check.yml（validate は対応済み、plan は service のみで適切）

## 可観測性/検証

deploy.yml → destroy.yml を実行し、全 root module が正常に apply/destroy されることを確認する。

## ロールバック

workflow の YAML 変更のみ。revert commit で即時復旧可能。deploy/destroy 自体は Terraform state に対する操作であり、workflow の revert でインフラへの影響はない。

## リリース連携
- **リリースノート**: 不要

Closes #398


Closes #398
