### PR TITLE
fix(terraform): cdn が service state から origin verify header を取得するように修正する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,6 @@ jobs:
             -var="enable_cloudfront=true" \
             -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
             -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
-            -var="alb_origin_verify_header_value=$(cd ../service && terraform output -raw alb_origin_verify_header_value 2>/dev/null || echo 'placeholder')" \
             -out=tfplan
           terraform apply -auto-approve tfplan
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -86,8 +86,7 @@ jobs:
           terraform destroy -auto-approve \
             -var="enable_cloudfront=true" \
             -var="acm_certificate_arn_us_east_1=${{ vars.ACM_CERTIFICATE_ARN_US_EAST_1 }}" \
-            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}" \
-            -var="alb_origin_verify_header_value=placeholder-for-destroy"
+            -var="hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}"
 
       - name: Destroy Infrastructure (service)
         working-directory: ./terraform/service

--- a/terraform/cdn/main.tf
+++ b/terraform/cdn/main.tf
@@ -28,7 +28,7 @@ module "cloudfront" {
   acm_certificate_arn_us_east_1  = var.acm_certificate_arn_us_east_1
   cloudfront_oac_id              = var.cloudfront_oac_id
   alb_origin_verify_header_name  = "X-Hannibal-Origin-Verify"
-  alb_origin_verify_header_value = var.alb_origin_verify_header_value
+  alb_origin_verify_header_value = data.terraform_remote_state.service.outputs.alb_origin_verify_header_value
 }
 
 module "dns" {

--- a/terraform/cdn/variables.tf
+++ b/terraform/cdn/variables.tf
@@ -49,9 +49,3 @@ variable "enable_cloudfront" {
   type        = bool
   default     = true
 }
-
-variable "alb_origin_verify_header_value" {
-  description = "Secret value for ALB origin verification header"
-  type        = string
-  sensitive   = true
-}

--- a/terraform/service/outputs.tf
+++ b/terraform/service/outputs.tf
@@ -52,3 +52,9 @@ output "sns_topic_arn" {
   description = "SNS topic ARN for alarm notifications"
   value       = module.monitoring.sns_topic_arn
 }
+
+output "alb_origin_verify_header_value" {
+  description = "ALB origin verify header value for CloudFront"
+  value       = random_password.alb_origin_verify_header.result
+  sensitive   = true
+}


### PR DESCRIPTION
## 目的

CloudFront → ALB の origin verify header 値が `placeholder` になり、API リクエストが 403 で拒否されるバグを修正する。

## 変更内容

- `service/outputs.tf`: `alb_origin_verify_header_value` output を追加（sensitive）
- `cdn/main.tf`: `var.alb_origin_verify_header_value` → `data.terraform_remote_state.service.outputs.alb_origin_verify_header_value`
- `cdn/variables.tf`: 不要になった `alb_origin_verify_header_value` 変数を削除
- `deploy.yml` / `destroy.yml`: cdn への `-var="alb_origin_verify_header_value=..."` を削除

## 影響範囲

- **対象**: cdn root module, service root module outputs, deploy/destroy workflow
- **非対象**: network, database, pr-check.yml

## 可観測性/検証

deploy 後にブラウザから `https://hamilcar-hannibal.click` にアクセスし、GraphQL API が JSON を返すことを確認する。

## ロールバック

Terraform コード変更 + workflow YAML 変更のみ。revert commit で即時復旧可能。cdn の `alb_origin_verify_header_value` 変数を復元し、deploy.yml に `-var` を戻せば旧構成に戻る（ただし旧構成はバグを含む）。

## リリース連携
- **リリースノート**: 不要

Closes #405


Closes #405
