### PR TITLE
docs: AGENTS.md と copilot-instructions.md を state 分割後の構成に更新する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,14 +110,19 @@ nestjs-hannibal-3/
 │   │   ├── billing.tf   # コスト監視 ($30-50 → 停止時$5)
 │   │   └── athena.tf    # CloudTrail分析
 │   ├── modules/         # 再利用可能モジュール
-│   │   ├── networking/  # 3層VPC (Public/App/Data)
-│   │   ├── compute/     # ECS Fargate + ALB
-│   │   ├── cicd/        # CodeDeploy Blue/Green
-│   │   ├── storage/     # RDS + S3
-│   │   ├── cdn/         # CloudFront
-│   │   ├── security/    # Security Groups
-│   │   └── observability/ # CloudWatch
-│   └── environments/dev/  # 環境別設定
+│   │   ├── vpc/         # 3層VPC (Public/App/Data) + Security Groups
+│   │   ├── rds/         # RDS PostgreSQL
+│   │   ├── ecs/         # ECS Fargate + IAM
+│   │   ├── load-balancer/ # ALB + Target Groups
+│   │   ├── codedeploy/  # CodeDeploy Blue/Green
+│   │   ├── cloudfront/  # CloudFront
+│   │   ├── s3/          # S3
+│   │   ├── dns/         # Route53
+│   │   └── monitoring/  # CloudWatch
+│   ├── network/         # root module: VPC + SG
+│   ├── database/        # root module: RDS
+│   ├── service/         # root module: ECS + ALB + CodeDeploy + monitoring
+│   └── cdn/             # root module: CloudFront + S3 + DNS
 ├── .github/workflows/
 │   ├── deploy.yml         # 3モード対応 (provisioning/bluegreen/canary)
 │   ├── security-scan.yml  # 手動 CodeQL/Trivy scan
@@ -235,7 +240,8 @@ npm run build      # 本番ビルド
 ### Infrastructure開発 (Terraform)
 
 ```bash
-cd terraform/environments/dev
+# 4 root module 構成: network → database → service → cdn
+cd terraform/service
 terraform init     # S3バックエンド初期化
 terraform plan     # 変更プレビュー
 terraform apply    # リソース作成
@@ -425,11 +431,7 @@ terraform plan -out=tfplan
 
 **停止方法** (`terraform/foundation/billing.tf` 参照):
 ```bash
-# GitHub Actions: destroy.yml で実行
-# または手動:
-cd terraform/environments/dev
-terraform destroy -target=module.compute
-terraform destroy -target=module.storage
+# GitHub Actions: destroy.yml で実行（cdn → service → database → network の逆順）
 ```
 
 **起動方法**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,37 @@ PR は原則として次のヘルパーで作成します。
   --head <branch>
 ```
 
+## Terraform 変更時の追加確認
+
+### 実行してよい検証コマンド
+
+```bash
+# フォーマットチェック（差分なしが正常）
+terraform fmt -check -recursive
+
+# 静的バリデーション（AWS 認証不要）
+for dir in terraform/foundation terraform/network terraform/database terraform/service terraform/cdn; do
+  terraform -chdir="$dir" init -backend=false
+  terraform -chdir="$dir" validate
+done
+```
+
+### ディレクトリ別の方針
+
+| ディレクトリ | 用途 | apply/destroy |
+|---|---|---|
+| `terraform/foundation/` | 基盤 IAM・OIDC 等（恒久リソース） | PR マージ後に人間が手動実行。`state rm` しない |
+| `terraform/network/` | VPC・subnet・Security Group | `deploy.yml` / `destroy.yml` から実行 |
+| `terraform/database/` | RDS PostgreSQL | `deploy.yml` / `destroy.yml` から実行 |
+| `terraform/service/` | ECS・ALB・CodeDeploy・monitoring | `deploy.yml` / `destroy.yml` から実行 |
+| `terraform/cdn/` | CloudFront・S3・DNS | `deploy.yml` / `destroy.yml` から実行 |
+
+### state 管理方針
+
+- `terraform/foundation/` の新規リソースは state に残して継続管理する
+- `terraform state rm` は原則行わない
+- `terraform/network/`、`terraform/database/`、`terraform/service/`、`terraform/cdn/` のリソースは deploy/destroy で自動管理される
+
 ## 禁止事項
 
 次は、ユーザーから明示された場合でも実行前に確認します。


### PR DESCRIPTION
## 目的

AI ルールファイルの Terraform ディレクトリ参照を state 分割後の 4 root module 構成に更新する。

## 変更内容

- `AGENTS.md`: Terraform セクション（ディレクトリ方針・validate コマンド・state 管理方針）を追加
- `.github/copilot-instructions.md`: ディレクトリツリーを 9 モジュール + 4 root module 構成に更新、旧パス `terraform/environments/dev/` を削除

## 影響範囲

- **対象**: `AGENTS.md`, `.github/copilot-instructions.md`
- **非対象**: `CLAUDE.md`（#397 で更新済み）、Terraform コード、workflow

## 可観測性/検証

No-op（ドキュメント変更のみ）。

## ロールバック

不要（軽運用）。

## リリース連携
- **リリースノート**: 不要

Closes #399


Closes #399
