### PR TITLE
docs: ADR 0003 に S3 lockfile 動作確認結果を追記する

### DIFF
--- a/docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md
+++ b/docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md
@@ -46,15 +46,20 @@ state locking はインフラ変更の安全性に直結するため、二段階
 ## 影響
 
 - 2026-05-31 時点: `use_lockfile = true` 有効 / DynamoDB lock table は併用継続 / DynamoDB 削除（#189）は未実施
+- 2026-06-21 時点: state 分割（#397）で新設した network / database / service / cdn の 4 root module を `use_lockfile = true` 単独に移行（#408）。`dynamodb_table` を削除し S3 lockfile のみで運用
+- 2026-06-21 動作確認: 全 4 root module で `terraform plan -lock=true` 実行中に `.tflock` の作成を確認、plan 終了後に削除を確認。DynamoDB なしで S3 lockfile が正常に機能している
 - 現在の正は S3 lockfile 方式
-- DynamoDB lock table は移行期間中のみ残す
-- DynamoDB 削除は #189 で扱う
+- foundation のみ `use_lockfile = true` + `dynamodb_table` 併用が残っている（#189 でテーブル削除と合わせて対応）
 - PR plan Role は `terraform plan -lock=false` 前提のため、S3 lockfile の write/delete 権限を持たない
 
 ## 関連
 
 - [Issue #183](https://github.com/kmryst/terraform-hannibal/issues/183)
 - [Issue #189](https://github.com/kmryst/terraform-hannibal/issues/189)
+- [Issue #408](https://github.com/kmryst/terraform-hannibal/issues/408)
 - [terraform/foundation/backend.tf](../../terraform/foundation/backend.tf)
-- [terraform/environments/dev/backend.tf](../../terraform/environments/dev/backend.tf)
+- [terraform/network/backend.tf](../../terraform/network/backend.tf)
+- [terraform/database/backend.tf](../../terraform/database/backend.tf)
+- [terraform/service/backend.tf](../../terraform/service/backend.tf)
+- [terraform/cdn/backend.tf](../../terraform/cdn/backend.tf)
 - [terraform/foundation/dynamodb.tf](../../terraform/foundation/dynamodb.tf)


### PR DESCRIPTION
## 目的

ADR 0003 に、state 分割後の全 4 root module で S3 lockfile の動作確認が完了した旨を追記する。

## 変更内容

- 「影響」セクションに #408 での移行完了と 2026-06-21 の動作確認結果を追記
- 「関連」セクションのリンクを旧構成（`environments/dev`）から state 分割後の 4 root module に更新

## 影響範囲

- **対象**: `docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md`
- **非対象**: ADR のステータス・決定内容は変更しない

## PRラベル（必須）
- **type**: `type:docs`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証

No-op（適用外）

## リリース連携
- **リリースノート**: 不要

Closes #411


Closes #411
