### PR TITLE
docs: ADR 0003にDynamoDB lock table撤去結果を記録する

### DIFF
--- a/docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md
+++ b/docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md
@@ -12,7 +12,7 @@ Accepted
 
 Terraform の S3 backend では `use_lockfile = true` による S3 lockfile 方式を正とする。
 
-DynamoDB state locking は使用せず、全 root module の backend と IAM 権限を S3 lockfile 単独運用に統一する。移行期間に使用した手動管理の DynamoDB table は、S3 lockfile の実動作確認後に削除する。
+DynamoDB state locking は使用せず、全 root module の backend と IAM 権限を S3 lockfile 単独運用に統一する。移行期間に使用した手動管理の DynamoDB table は、S3 lockfile の実動作確認後に削除した。
 
 ## 背景
 
@@ -50,7 +50,9 @@ state locking はインフラ変更の安全性に直結するため、二段階
 - 2026-06-21 動作確認: 全 4 root module で `terraform plan -lock=true` 実行中に `.tflock` の作成を確認、plan 終了後に削除を確認。DynamoDB なしで S3 lockfile が正常に機能している
 - 2026-06-21 #189: foundation の `dynamodb_table` と全 Role / Permission Boundary の DynamoDB lock 権限を削除し、全 5 root module を S3 lockfile 単独構成へ統一
 - 2026-06-21 #189 マージ前確認: Foundation Role で `terraform init -reconfigure` と lock あり real plan を実行し、`.tflock` の作成・終了後削除を確認。plan は IAM policy 6件の in-place 更新のみ（`0 to add, 6 to change, 0 to destroy`）
-- 手動管理の旧 `terraform-state-lock` table は、#189 のマージ後に foundation apply と S3 lockfile 単独の real plan を確認してから削除する。実施結果は Issue #189 に記録する
+- 2026-06-21 #189 対照試験: Foundation Role に `dynamodb:*` の明示 Deny を付けた session で `terraform init -reconfigure` と lock あり real plan が成功し、DynamoDB 権限なしで S3 lockfile 単独運用が成立することを確認
+- 2026-06-21 #189 IAM 反映: bootstrap 権限で IAM policy 6件を in-place 更新（`0 added, 6 changed, 0 destroyed`）。反映後に Foundation Role で lock あり real plan が `No changes` となり、Developer / CICD / Foundation Role の旧 DynamoDB lock 操作が `implicitDeny` であることを確認
+- 2026-06-21 #189 table 撤去: 実行中 workflow と全 5 root module の `.tflock` がなく、旧 table の 6件がすべて state digest の `-md5` レコードであることを確認してから、手動管理の DynamoDB table `terraform-state-lock` を削除。削除後の `DescribeTable` は `ResourceNotFoundException`、Foundation Role の lock あり real plan は `No changes`
 - 現在の正は全 5 root module の S3 lockfile 単独運用
 - PR plan Role は `terraform plan -lock=false` 前提のため、S3 lockfile の write/delete 権限を持たない
 
@@ -59,6 +61,7 @@ state locking はインフラ変更の安全性に直結するため、二段階
 - [Issue #183](https://github.com/kmryst/terraform-hannibal/issues/183)
 - [Issue #189](https://github.com/kmryst/terraform-hannibal/issues/189)
 - [Issue #408](https://github.com/kmryst/terraform-hannibal/issues/408)
+- [PR #413](https://github.com/kmryst/terraform-hannibal/pull/413)
 - [terraform/foundation/backend.tf](../../terraform/foundation/backend.tf)
 - [terraform/network/backend.tf](../../terraform/network/backend.tf)
 - [terraform/database/backend.tf](../../terraform/database/backend.tf)


### PR DESCRIPTION
## 目的（推奨）

Issue #189 のマージ後作業として実施した DynamoDB lock table 撤去結果を ADR 0003 に記録し、Terraform state locking の現在の正を S3 lockfile 単独運用として明文化する。

## 変更内容（推奨）

- ADR 0003 の DynamoDB table 記述を未実施から実施済みに更新
- `dynamodb:*` 明示 Deny による対照試験、IAM policy 反映、DynamoDB table 削除後確認の結果を追記
- 関連リンクに PR #413 を追加

## 影響範囲（推奨）

- **対象**: ADR 0003 の state locking 移行完了記録
- **非対象**: Terraform 設定、IAM policy、AWS リソース、CI/CD workflow

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`, `area:infra`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。docs-only。

**コスト根拠**: なし。AWS リソース変更なし。

**リスク根拠**: 変更自体は docs-only だが、IAM / Terraform state locking の運用完了記録であり Issue #189 の厳密運用を閉じるため `risk:medium` とする。

</details>

## 可観測性/検証 *条件付き*

- Claude Code による ADR 差分の軽レビュー: ブロッカーなし
- `git diff --check -- docs/adr/0003-migrate-terraform-state-locking-to-s3-lockfile.md`
- `npm run commitlint -- --from main --to HEAD --verbose`
- PR title commitlint
- pre-commit hook: `Detect hardcoded secrets` passed（Terraform 系 hook は対象ファイルなしで skipped）

## ロールバック *条件付き*

本 PR を revert する。docs-only のため AWS リソースや Terraform state のロールバックは不要。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- `git diff --check`: success
- commitlint: success
- PR title commitlint: success
- secret scan hook: passed

</details>

## メモ（レビューポイント）

- Issue #189 コメントに記録済みの対照試験、IAM apply、table 削除結果を ADR の履歴として残す変更
- Terraform / AWS リソースへの追加変更はなし


Closes #189
