### PR TITLE
docs: Preview Environmentの再検討条件を明記

### DIFF
--- a/docs/adr/0019-adopt-pr-preview-environment-with-isolated-state.md
+++ b/docs/adr/0019-adopt-pr-preview-environment-with-isolated-state.md
@@ -6,6 +6,8 @@ Superseded
 
 Terraform state をサービス単位で分割する設計を先に行い、その上で Preview 構成を再検討する方針に変更した。モノリシックな環境 state を前提に PR 単位で全リソースを複製する本 ADR の構成は、state 分割後には不要になる可能性が高い。
 
+その後、Preview Environment は state 分割だけを再検討トリガーにせず、dev deploy/destroy、rollback、CI runtime check、cost guardrail などの基礎運用が安定してから再検討する方針に整理した。最新の再検討条件は [Terraform 環境分離設計](../terraform-environments.md#pr-preview-environment) を正とする。
+
 ## 日付
 
 2026-06-20

--- a/docs/terraform-environments.md
+++ b/docs/terraform-environments.md
@@ -6,7 +6,7 @@
 
 `terraform/foundation/` は IAM / OIDC / Permission Boundary などの永続基盤を管理します（ADR 0014）。アプリケーションリソースは責務ごとに 4 つの root module に分割します（ADR 0020）。
 
-Preview Environment は state 分割後の構成を前提に再検討します（ADR 0019 Superseded）。
+Preview Environment は現時点では本格設計・実装せず、dev deploy/destroy や rollback などの基礎運用が安定してから再検討します（ADR 0019 Superseded）。
 
 ## State 管理方針
 
@@ -106,7 +106,18 @@ terraform/modules/
 
 ## PR Preview Environment
 
-PR 単体の変更を一時 AWS 環境で確認する Preview Environment は、state 分割後の構成を前提に再検討します。以前の検討内容は [ADR 0019](./adr/0019-adopt-pr-preview-environment-with-isolated-state.md)（Superseded）を参照してください。
+現時点では Preview Environment の本格設計・実装は優先しません。
+
+Preview Environment は dev / staging / production の代替ではなく、PR 単位の一時環境として扱います。現在は dev deploy/destroy、rollback、CI runtime check、cost guardrail を安定させる段階です。この段階で Preview Environment を先に実装すると、未解決の deploy / rollback 課題を環境数ぶん増幅する可能性があります。
+
+そのため、Preview Environment は今すぐ作る対象ではなく、次の条件が揃った時点で再検討します。
+
+- dev deploy/destroy が安定している
+- rollback / observability / secrets handling が最低限整っている
+- staging / production 相当の昇格モデルを説明できる
+- preview 環境の state isolation / IAM / 自動 destroy / cost guardrail を設計できる
+
+以前の検討内容は [ADR 0019](./adr/0019-adopt-pr-preview-environment-with-isolated-state.md)（Superseded）を参照してください。
 
 ## 後続フェーズ
 
@@ -114,7 +125,7 @@ PR 単体の変更を一時 AWS 環境で確認する Preview Environment は、
 2. 子モジュールの責務整理とディレクトリフラット化を実施する
 3. CI / workflow（`pr-check.yml`、`deploy.yml`、`destroy.yml`）を新しい root module 構成に対応させる
 4. staging / production を独立した共有環境として整備し、直列 deploy と承認を設計する
-5. state 分割後の構成を前提に、Preview Environment を再検討する
+5. dev deploy/destroy や rollback などの基礎運用が安定した後、Preview Environment を再検討する
 
 ## 新環境（staging / prod）を追加するときのチェックリスト
 

--- a/docs/terraform-environments.md
+++ b/docs/terraform-environments.md
@@ -110,12 +110,15 @@ terraform/modules/
 
 Preview Environment は dev / staging / production の代替ではなく、PR 単位の一時環境として扱います。現在は dev deploy/destroy、rollback、CI runtime check、cost guardrail を安定させる段階です。この段階で Preview Environment を先に実装すると、未解決の deploy / rollback 課題を環境数ぶん増幅する可能性があります。
 
-そのため、Preview Environment は今すぐ作る対象ではなく、次の条件が揃った時点で再検討します。
+そのため、Preview Environment は今すぐ作る対象ではなく、次の条件が揃った時点で再検討します。再検討時は、関連 Issue が close されているか、未完了の場合は代替策または accepted risk が docs に記録されていることを確認します。
 
-- dev deploy/destroy が安定している
-- rollback / observability / secrets handling が最低限整っている
+- dev deploy/destroy が安定している（例: provisioning 誤選択 guard、CodeDeploy / ALB listener 整合性）
+- rollback / observability / secrets handling が最低限整っている（例: RDS secret 参照、rollback readiness、監視アラーム）
+- CI runtime check が production 起動時の主要な失敗を検知できる（例: Docker production smoke test、AppModule + PostgreSQL E2E）
 - staging / production 相当の昇格モデルを説明できる
 - preview 環境の state isolation / IAM / 自動 destroy / cost guardrail を設計できる
+
+主な関連 Issue は #378、#380、#381、#382、#383、#186 を参照します。
 
 以前の検討内容は [ADR 0019](./adr/0019-adopt-pr-preview-environment-with-isolated-state.md)（Superseded）を参照してください。
 


### PR DESCRIPTION
## 目的（推奨）

#395 の Preview Environment 再設計について、現時点では本格設計・実装を優先しない判断と再検討条件を docs に残す。

## 変更内容（推奨）

- `docs/terraform-environments.md` の概要、`PR Preview Environment` 節、後続フェーズを更新
- Preview Environment を dev / staging / production の代替ではなく PR 単位の一時環境として位置づけ
- dev deploy/destroy、rollback、CI runtime check、cost guardrail が安定してから再検討する条件を明記
- `docs/adr/0019-adopt-pr-preview-environment-with-isolated-state.md` の Superseded 説明から最新の再検討条件へ誘導

## 影響範囲（推奨）

- **対象**: Terraform 環境分離設計ドキュメント、Superseded ADR 0019
- **非対象**: Terraform 実装、GitHub Actions、IAM、AWS リソース

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

No-op（docs-only のため適用外）

## ロールバック *条件付き*

軽運用 PR のため必須ではない。必要な場合は本 PR を revert し、Preview Environment の再検討条件に関する docs 変更を戻す。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- `git diff --check`
- `npm run commitlint -- --from main --to HEAD --verbose`
- PR title の commitlint
- commit 時 pre-commit hook: Terraform checks skipped（対象なし）、hardcoded secrets scan passed

</details>

## メモ（レビューポイント）

- Preview Environment を今すぐ実装しない理由と、再検討条件の粒度が妥当か
- #395 に方針転換コメントを追加済み: https://github.com/kmryst/terraform-hannibal/issues/395#issuecomment-4806244402

Closes #395