### PR TITLE
test(ci): add production Docker smoke test

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -149,14 +149,14 @@ jobs:
           docker run -d \
             --name smoke-app \
             --network smoke-test-net \
-            -p 3000:3000 \
             -e NODE_ENV=production \
             -e DATABASE_URL="postgresql://smoke:smoke@smoke-db:5432/smoke?sslmode=disable" \
             hannibal-test
 
           app_healthy=false
           for attempt in {1..15}; do
-            if curl -sf http://localhost:3000/health >/dev/null; then
+            if docker run --rm --network smoke-test-net curlimages/curl \
+                -sf http://smoke-app:3000/health >/dev/null 2>&1; then
               app_healthy=true
               break
             fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -118,6 +118,72 @@ jobs:
           echo "Container running as: $user"
           [ "$user" = "node" ] || { echo "::error::Expected 'node' user, got '$user'"; exit 1; }
 
+      - name: Smoke test production startup
+        run: |
+          set -euo pipefail
+
+          docker network create smoke-test-net
+
+          docker run -d \
+            --name smoke-db \
+            --network smoke-test-net \
+            -e POSTGRES_USER=smoke \
+            -e POSTGRES_PASSWORD=smoke \
+            -e POSTGRES_DB=smoke \
+            postgres:16-alpine
+
+          for attempt in {1..15}; do
+            if docker exec smoke-db pg_isready -U smoke -d smoke; then
+              break
+            fi
+
+            if [ "$attempt" -eq 15 ]; then
+              echo "::error::PostgreSQL did not become ready"
+              docker logs smoke-db || true
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          docker run -d \
+            --name smoke-app \
+            --network smoke-test-net \
+            -p 3000:3000 \
+            -e NODE_ENV=production \
+            -e DATABASE_URL="postgresql://smoke:smoke@smoke-db:5432/smoke?sslmode=disable" \
+            hannibal-test
+
+          app_healthy=false
+          for attempt in {1..15}; do
+            if curl -sf http://localhost:3000/health >/dev/null; then
+              app_healthy=true
+              break
+            fi
+
+            if ! docker ps --format '{{.Names}}' | grep -qx smoke-app; then
+              echo "::error::Application container exited before health check passed"
+              docker logs smoke-app || true
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          if [ "$app_healthy" != "true" ]; then
+            echo "::error::Application did not become healthy"
+            docker logs smoke-app || true
+            exit 1
+          fi
+
+          echo "Production startup smoke test passed."
+
+      - name: Cleanup smoke test containers
+        if: always()
+        run: |
+          docker rm -f smoke-app smoke-db 2>/dev/null || true
+          docker network rm smoke-test-net 2>/dev/null || true
+
   terraform-check:
     name: Terraform Format & Validate
     runs-on: ubuntu-latest

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -19,7 +19,7 @@
 | `Backend Test` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | Jest | backend unit test を確認 | PR で自動実行 |
 | `Frontend Build` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | TypeScript / Vite build | frontend の型チェックと build を確認 | required status check 対象 |
 | `Frontend Test` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | Vitest | frontend unit test を確認 | PR で自動実行 |
-| `Docker Build` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | Docker | backend image build と non-root user を確認 | PR で自動実行 |
+| `Docker Build` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | Docker | backend image build、non-root user、production 起動 smoke test を確認 | PR で自動実行 |
 | `Terraform Format & Validate` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `terraform fmt` / `terraform validate` | HCL の整形と Terraform 構成の基本整合性を確認 | required status check 対象 |
 | `TFLint` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `tflint` | Terraform / AWS provider 向けの lint。非推奨設定、未使用宣言、provider 固有のミスを検出 | required status check 対象。検出時は fail |
 | `Trivy Config Scan` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `trivy config` | Terraform / Dockerfile などの IaC・設定ミスを検出 | PR で自動実行。review signal として扱い、検出しても fail しない |


### PR DESCRIPTION
## 目的（推奨）

Docker image の build 成功だけでなく、`NODE_ENV=production` の実コンテナ起動時クラッシュを PR 時点で検知できるようにする。

## 変更内容（推奨）

- `Docker Build` job に PostgreSQL test DB と production app container の `/health` smoke test を追加
- smoke test 用 container / network を `if: always()` で cleanup する step を追加
- `docs/operations/quality-gates.md` の Docker Build 説明を更新

## 影響範囲（推奨）

- **対象**: `.github/workflows/pr-check.yml` の `Docker Build` job、quality gate docs
- **非対象**: アプリケーション本体、Terraform、AWS リソース、Terraform plan CI の再導入

## PRラベル（必須）

- **type**: `type:test`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。PR CI の検証追加のみ。
**コスト根拠**: なし。GitHub Actions runner 上の Docker container 起動のみで、AWS リソースは変更しない。
**リスク根拠**: `.github/workflows/**` の変更を含むため厳密運用。ただし対象は PR CI の Docker Build job に限定され、失敗時は PR merge 前に検知される。

</details>

## 可観測性/検証 *条件付き*

- `docker build -t hannibal-test .`
- `docker run --rm hannibal-test whoami` で non-root user が `node` であることを確認
- `postgres:16-alpine` と `hannibal-test` を Docker network 上で起動し、`NODE_ENV=production` + `DATABASE_URL=...sslmode=disable` で `/health` が 200 を返すことを確認
- `actionlint .github/workflows/pr-check.yml`
- `git diff --check`
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*

本 PR の revert、または `.github/workflows/pr-check.yml` の production startup smoke test / cleanup step と `docs/operations/quality-gates.md` の説明更新を削除する。AWS リソース変更はないため、インフラ側の rollback は不要。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

ローカル検証では Docker image build、non-root user 確認、PostgreSQL 起動、production app container の `/health` smoke test が成功した。

</details>

## メモ（レビューポイント）

- `/health` は `NestFactory.create(AppModule)` と `configureApplication()` が成功した後でのみ応答するため、production bootstrap の smoke test として扱う。
- #373 の AppModule + PostgreSQL E2E とは分離し、本 PR では Docker image の production runtime 起動確認に scope を絞る。


Closes #381
