### PR TITLE
ci: provisioningモードの誤選択を検知する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,14 @@ on:
   workflow_dispatch:
     inputs:
       deployment_mode:
-        description: "デプロイモードを選択"
+        description: "canary/bluegreenはCodeDeploy実行、provisioningは初回構築専用（CodeDeployなし）"
         required: true
         default: "canary"
         type: choice
         options:
-          - canary         # 1回目以降（Canary段階的切替）
-          - bluegreen      # 1回目以降（Blue/Green切替）
-          - provisioning   # 0回目（初期構築・Blueのみ）
+          - canary         # 1回目以降（CodeDeploy Canary段階的切替）
+          - bluegreen      # 1回目以降（CodeDeploy Blue/Green切替）
+          - provisioning   # 0回目（初期構築専用・CodeDeployなし）
 
 jobs:
   deploy:
@@ -39,6 +39,84 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq unzip
           jq --version
+
+      - name: Validate deployment mode
+        env:
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+        run: |
+          set -euo pipefail
+
+          CLUSTER_NAME="${PROJECT_NAME}-cluster"
+          SERVICE_NAME="${PROJECT_NAME}-api-service"
+
+          {
+            echo "## Deployment mode"
+            echo ""
+            echo "- Selected mode: \`${DEPLOYMENT_MODE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$DEPLOYMENT_MODE" != "provisioning" ]; then
+            {
+              echo "- CodeDeploy: will run the \`${DEPLOYMENT_MODE}\` deployment step."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "- CodeDeploy: will not run in provisioning mode."
+            echo "- Provisioning is only allowed when the ECS service does not already exist."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          set +e
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --output json 2>ecs-describe-services-error.log)
+          DESCRIBE_EXIT=$?
+          set -e
+
+          if [ "$DESCRIBE_EXIT" -ne 0 ]; then
+            if grep -q "ClusterNotFoundException" ecs-describe-services-error.log; then
+              {
+                echo "- ECS service guard: cluster not found. Treating this as initial provisioning."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
+            cat ecs-describe-services-error.log >&2
+            echo "::error::Failed to inspect ECS service before provisioning."
+            {
+              echo "- ECS service guard: failed to inspect the service. Stopping to avoid unsafe provisioning."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          SERVICE_STATUS=$(echo "$SERVICE_JSON" | jq -r '.services[0].status // "MISSING"')
+          FAILURE_REASON=$(echo "$SERVICE_JSON" | jq -r '.failures[0].reason // ""')
+
+          if [ "$SERVICE_STATUS" = "ACTIVE" ] || [ "$SERVICE_STATUS" = "DRAINING" ]; then
+            echo "::error::ECS service $SERVICE_NAME is $SERVICE_STATUS. Use canary or bluegreen instead of provisioning."
+            {
+              echo "- ECS service guard: \`${SERVICE_NAME}\` is \`${SERVICE_STATUS}\`."
+              echo "- Result: provisioning is blocked for an existing environment. Use \`canary\` or \`bluegreen\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "$SERVICE_STATUS" = "INACTIVE" ] || [ "$SERVICE_STATUS" = "MISSING" ] || [ "$FAILURE_REASON" = "MISSING" ]; then
+            {
+              echo "- ECS service guard: service status is \`${SERVICE_STATUS}\`."
+              echo "- Result: provisioning is allowed."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::Unexpected ECS service status '$SERVICE_STATUS'. Stopping to avoid unsafe provisioning."
+          {
+            echo "- ECS service guard: unexpected service status \`${SERVICE_STATUS}\`."
+            echo "- Result: provisioning is blocked until the service state is reviewed."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -167,6 +245,7 @@ jobs:
           echo "✅ Docker image pushed with SHA and latest tags"
 
       - name: Generate AppSpec for ECS CodeDeploy
+        if: ${{ inputs.deployment_mode != 'provisioning' }}
         run: |
           set -e
           aws ecs describe-task-definition \
@@ -232,6 +311,7 @@ jobs:
           echo "✅ Canary deployment finished successfully!"
 
       - name: Cleanup old task definition revisions
+        if: ${{ inputs.deployment_mode != 'provisioning' }}
         # ECRライフサイクルポリシーが直近10イメージを保持するため、タスク定義も10世代に揃える
         run: |
           set -e

--- a/docs/deployment/codedeploy-blue-green.md
+++ b/docs/deployment/codedeploy-blue-green.md
@@ -7,9 +7,9 @@ nestjs-hannibal-3プロジェクトのCodeDeployデプロイメント実装
 AWS CodeDeployを使用したECSサービスのデプロイメント。3つのモードに対応。
 
 ### デプロイモード
-- **Canary**: 10%→100%段階的切替
-- **Blue/Green**: 即座切替
-- **Provisioning**: 初期構築
+- **Canary**: 10%→100%段階的切替（CodeDeploy 実行）
+- **Blue/Green**: 即座切替（CodeDeploy 実行）
+- **Provisioning**: 初期構築専用（CodeDeploy なし）
 
 ### 主要機能
 - **無停止デプロイメント**: Blue/Green環境での安全な切り替え
@@ -122,7 +122,7 @@ resource "aws_codedeploy_deployment_group" "main" {
 #### デプロイ設定
 - **`deployment_type = "canary"`**: `CodeDeployDefault.ECSCanary10Percent5Minutes`
 - **`deployment_type = "bluegreen"`**: `CodeDeployDefault.ECSAllAtOnce`
-- **`deployment_mode = "provisioning"`**: `deploy.yml` では Terraform apply 用に `deployment_type` を `canary` として扱い、CodeDeploy deployment step は実行しない
+- **`deployment_mode = "provisioning"`**: `deploy.yml` では Terraform apply 用に `deployment_type` を `canary` として扱い、CodeDeploy deployment step は実行しない。既存 ECS service がある場合は、誤選択として Terraform apply 前に workflow を失敗させる
 - **Termination Wait**: deployment 成功後、旧 task set を 1分後に終了
 
 ### IAM権限（最小権限原則）

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -47,6 +47,9 @@
 
 ### サービス起動（月初など）
 
+通常 destroy 済みの dev 環境を再作成する場合だけ `provisioning` を使います。
+`provisioning` は CodeDeploy を実行しません。既存 ECS service がある状態で選ぶと、`deploy.yml` は Terraform apply 前に失敗します。
+
 **GitHub Actions手動実行:**
 ```
 Workflow: deploy.yml
@@ -72,6 +75,9 @@ Inputs:
 **コスト削減**: $30-50/月 → $5/月 (94%削減)
 
 ### デプロイ実行（コード更新時）
+
+既存環境へのコード更新では `bluegreen` または `canary` を使います。
+`provisioning` は初回構築専用で、CodeDeploy によるデプロイや自動ロールバックを実行しません。
 
 **Blue/Green Deployment:**
 ```

--- a/docs/operations/terraform-runbook.md
+++ b/docs/operations/terraform-runbook.md
@@ -170,6 +170,7 @@ gh workflow run deploy.yml \
 
 `deployment_mode` は `provisioning` / `bluegreen` / `canary` のいずれかです。
 `provisioning` は初回構築用で、Terraform の `deployment_type` としては `canary` を使います。
+`provisioning` では CodeDeploy deployment step を実行しません。既存 ECS service がある場合は誤選択として、`deploy.yml` が Terraform apply 前に失敗します。
 
 local の `terraform apply` は例外運用です。
 実行する場合は、Issue / PR / rollback 方針 / 人間確認を揃え、`-auto-approve` を使わず保存済み plan を apply します。


### PR DESCRIPTION
## 目的（推奨）

既存 ECS service がある状態で `deployment_mode=provisioning` を誤選択した場合に、CodeDeploy を実行しないまま workflow が成功扱いになることを防ぐ。

## 変更内容（推奨）

- `deploy.yml` に `Validate deployment mode` ステップを追加し、`provisioning` 時は Terraform apply 前に ECS service の状態を確認する
- `ACTIVE` / `DRAINING` の ECS service がある場合は `provisioning` を失敗させ、`canary` / `bluegreen` の利用を促す
- `provisioning` では CodeDeploy が実行されないことを GitHub Actions Summary に明示する
- `provisioning` 時は AppSpec 生成と task definition cleanup を skip する
- 運用 docs に `provisioning` の初回構築専用ガードを反映する

## 影響範囲（推奨）

- **対象**: `deploy.yml` の手動 deploy workflow、関連する運用ドキュメント
- **非対象**: Terraform リソース定義、AWS リソース、`destroy.yml`、CodeDeploy の canary / bluegreen 実行ロジック

## PRラベル（必須）

- **type**: `type:bug`
- **area**: `area:ci-cd`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし。workflow guard の追加であり、既存稼働環境への直接変更はありません。
**コスト根拠**: AWS リソース追加なし。
**リスク根拠**: deploy workflow の挙動変更を含むため `risk:medium`。誤選択時は Terraform apply 前に fail する設計です。

</details>

## 可観測性/検証 *条件付き*

- `actionlint .github/workflows/deploy.yml`
- `git diff --check`
- mock AWS response による guard 分岐確認
  - `canary` / `bluegreen`: success
  - `provisioning` + cluster missing / service missing / `INACTIVE`: success
  - `provisioning` + `ACTIVE` / `DRAINING` / unknown status / AWS error: failure
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*

この PR を revert する。revert により `Validate deployment mode`、`provisioning` 時の AppSpec / cleanup skip、docs 追記が戻り、従来の deploy workflow 挙動に戻る。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```text
actionlint .github/workflows/deploy.yml
# success

git diff --check
# success

npm run commitlint -- --from main --to HEAD --verbose
# found 0 problems, 0 warnings
```

</details>

## メモ（レビューポイント）

- `provisioning` は ECS service が存在しない初回構築または destroy 後の再構築だけ許可します。
- 既存 ECS service が `ACTIVE` / `DRAINING` の場合は Terraform apply 前に workflow を失敗させます。
- `ClusterNotFoundException`、service `MISSING`、service `INACTIVE` は初回/再構築可能な状態として許可します。


Closes #382
