### PR TITLE
docs: ADR 0024 — pre-commit と CI の二層で lint を実行する設計判断を記録する

### DIFF
--- a/docs/adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md
+++ b/docs/adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md
@@ -1,0 +1,71 @@
+# 0024. シェルスクリプト / Dockerfile の lint を pre-commit と CI の二層で実行する
+
+## ステータス
+
+Accepted
+
+## 日付
+
+2026-06-27
+
+## 決定内容
+
+ShellCheck / Hadolint を pre-commit フックと CI（`pr-check.yml`）の両方に組み込み、二層で実行する。
+
+- pre-commit: ローカルコミット時に即時フィードバックを返す
+- CI: PR 上で全開発者に対して強制実行し、検出時に job fail させる
+
+shfmt は formatter のため CI には追加せず pre-commit のみとする（この判断はスコープ外）。
+
+## 背景
+
+Issue #426 で `scripts/**/*.sh`（4 本）と `Dockerfile` の静的解析を導入した。
+それ以前は lint なしでコミットできる状態であり、pre-commit / CI のチェックが空白だった。
+
+lint を追加するにあたり、どの層に置くかを検討する必要があった。
+
+## 検討した選択肢
+
+### pre-commit のみ（不採択）
+
+- 長所: ローカルで即座にフィードバックが得られ、CI のキュー待ちが不要
+- 短所: `git commit --no-verify` で hook を意図的にスキップできる
+- 短所: `pre-commit install` を実行していない開発者には hook が存在しない
+- 短所: GitHub Actions 環境では pre-commit は実行されず、CI として機能しない
+
+### CI のみ（不採択）
+
+- 長所: push / PR 作成後に全員へ強制される
+- 長所: ローカル環境のセットアップ状態に左右されない
+- 短所: コミット後に push するまでフィードバックが来ない
+- 短所: ローカルで即座に気づける問題を CI まで引っ張るため、手戻りが大きい
+
+### pre-commit と CI の両方（採択）
+
+- 長所: ローカルでの早期発見（速さ）と CI による強制実行（確実性）を両立できる
+- 長所: `--no-verify` や install 忘れによる抜け穴を CI が補完する
+- 短所: 同じ check を二か所に定義するため、設定の同期を維持する必要がある
+
+## 採択理由
+
+pre-commit と CI はそれぞれ異なる問題を解決する。
+
+pre-commit はローカルで即座にフィードバックを返すが、強制力がない。
+CI は全員に強制するが、フィードバックが push 後になる。
+
+どちらか一方では「速いが抜け穴がある」か「確実だが遅い」になる。
+二層にすることで速さと強制力を両立できる。
+
+なお、ShellCheck / Hadolint は初期導入時点で branch protection の required status check には追加しない。観察期間後に false positive・実行時間・merge blocking にする価値を確認してから判断する（ADR 0013 の方針に従う）。
+
+## 影響
+
+- lint の設定変更は `.pre-commit-config.yaml` と `pr-check.yml` の両方を更新する必要がある
+- ルールを追加・変更した場合は、既存スクリプト / Dockerfile がパスすることを両層で確認する
+- ShellCheck / Hadolint の required 化判断は ADR 0013 の方針に従い、別 Issue で実施する
+
+## 関連
+
+- [Issue #426](https://github.com/kmryst/terraform-hannibal/issues/426) - ShellCheck / shfmt / Hadolint 導入
+- [ADR 0013](./0013-promote-quality-checks-to-required-gradually.md) - 品質チェックを観察期間後に段階的 required 化する
+- [Quality Gates](../operations/quality-gates.md) - PR 品質ゲートと required 化判断の正本

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,3 +63,4 @@
 | [0021](./0021-pause-pr-terraform-plan-artifact.md) | Accepted | PR Terraform Plan Artifact を一時停止する |
 | [0022](./0022-keep-prod-rds-on-t3-micro-until-metrics-justify-scale-up.md) | Accepted | prod RDS はメトリクスが引き上げを正当化するまで db.t3.micro に据え置く |
 | [0023](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md) | Accepted | ローカルツール管理に mise を採用し terraform-docs は pre-commit で運用する |
+| [0024](./0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) | Accepted | シェルスクリプト / Dockerfile の lint を pre-commit と CI の二層で実行する |

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -36,6 +36,7 @@
 - shfmt は formatter のため、PR workflow では実行せず pre-commit の差分チェックに留める
 - ShellCheck / Hadolint は初期導入時点では required status check に追加しない
 - 観察期間後、false positive、実行時間、PR 運用への影響、merge blocking にする価値を見て required 化を別 Issue で判断する
+- pre-commit と CI の両方に置く理由（速さと強制力の両立）は [ADR 0024](../adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) に記録する
 
 Hadolint の `DL3018` は `.hadolint.yaml` で ignore します。
 `Dockerfile` では RDS CA 証明書を取得するために image build 中だけ一時的に `wget` を入れ、取得後に `apk del wget` で削除しています。


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
<!-- なぜこの変更が必要か（1-2行）。軽微変更なら簡潔でOK -->

## 変更内容（推奨）
<!-- 具体的に何を変更したか（1行要点） -->

## 影響範囲（推奨）
<!-- 対象/非対象の一言 -->
- **対象**: 
- **非対象**: 

## PRラベル（必須）
- **type**: ちょうど1つ必須
- **area**: 1つ以上必須、複数可
- **risk**: ちょうど1つ必須
- **cost**: ちょうど1つ必須
- **例**: `type:docs`, `area:docs`, `risk:low`, `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）:
**コスト根拠**（小/中/大の場合）:
**リスク根拠**（Medium/Highの場合）:

</details>

## 可観測性/検証 *条件付き*
<!-- Doc-onlyなら"No-op（適用外）"、それ以外は指標・期間・合格条件 -->

## ロールバック *条件付き*
<!-- 厳密運用PRでは必須。軽運用PRでは必要時のみ -->

## リリース連携（推奨）
- **リリースノート**: 要 / 不要

<details>
<summary>テスト結果/検証手順</summary>

</details>

## メモ（レビューポイント）
<!-- レビュアーに見てほしい箇所 -->

Closes # *必須*


Closes #432
