### PR TITLE
docs: ADR 0024 を Deprecated に変更し quality-gates.md の説明をインライン化する

### DIFF
--- a/docs/adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md
+++ b/docs/adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md
@@ -2,7 +2,12 @@
 
 ## ステータス
 
-Accepted
+Deprecated
+
+> この ADR は廃止しました。
+> 記録した内容（pre-commit は速いが突破可能、CI は強制力があるがフィードバックが遅い、だから両方）は
+> DevOps の一般常識であり、プロジェクト固有の判断を記録する ADR の対象ではありませんでした。
+> 二層にする理由は [Quality Gates](../operations/quality-gates.md) の #426 セクションにインラインで記載しています。
 
 ## 日付
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,4 +63,4 @@
 | [0021](./0021-pause-pr-terraform-plan-artifact.md) | Accepted | PR Terraform Plan Artifact を一時停止する |
 | [0022](./0022-keep-prod-rds-on-t3-micro-until-metrics-justify-scale-up.md) | Accepted | prod RDS はメトリクスが引き上げを正当化するまで db.t3.micro に据え置く |
 | [0023](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md) | Accepted | ローカルツール管理に mise を採用し terraform-docs は pre-commit で運用する |
-| [0024](./0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) | Accepted | シェルスクリプト / Dockerfile の lint を pre-commit と CI の二層で実行する |
+| [0024](./0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) | Deprecated | シェルスクリプト / Dockerfile の lint を pre-commit と CI の二層で実行する |

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -36,7 +36,7 @@
 - shfmt は formatter のため、PR workflow では実行せず pre-commit の差分チェックに留める
 - ShellCheck / Hadolint は初期導入時点では required status check に追加しない
 - 観察期間後、false positive、実行時間、PR 運用への影響、merge blocking にする価値を見て required 化を別 Issue で判断する
-- pre-commit と CI の両方に置く理由（速さと強制力の両立）は [ADR 0024](../adr/0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) に記録する
+- pre-commit と CI の両方に置く理由：pre-commit は速いが `--no-verify` で突破可能・`pre-commit install` 忘れのリスクがある。CI は全員に強制されるがフィードバックが push 後になる。二層にすることで速さと強制力を両立する
 
 Hadolint の `DL3018` は `.hadolint.yaml` で ignore します。
 `Dockerfile` では RDS CA 証明書を取得するために image build 中だけ一時的に `wget` を入れ、取得後に `apk del wget` で削除しています。


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
<!-- なぜこの変更が必要か（1-2行）。軽微変更なら簡潔でOK -->

## 変更内容（推奨）
<!-- 具体的に何を変更したか（1行要点） -->

## 影響範囲（推奨）
<!-- 対象/非対象の一言 -->
- **対象**: 
- **非対象**: 

## PRラベル（必須）
- **type**: ちょうど1つ必須
- **area**: 1つ以上必須、複数可
- **risk**: ちょうど1つ必須
- **cost**: ちょうど1つ必須
- **例**: `type:docs`, `area:docs`, `risk:low`, `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）:
**コスト根拠**（小/中/大の場合）:
**リスク根拠**（Medium/Highの場合）:

</details>

## 可観測性/検証 *条件付き*
<!-- Doc-onlyなら"No-op（適用外）"、それ以外は指標・期間・合格条件 -->

## ロールバック *条件付き*
<!-- 厳密運用PRでは必須。軽運用PRでは必要時のみ -->

## リリース連携（推奨）
- **リリースノート**: 要 / 不要

<details>
<summary>テスト結果/検証手順</summary>

</details>

## メモ（レビューポイント）
<!-- レビュアーに見てほしい箇所 -->

Closes # *必須*


Closes #434
