### PR TITLE
fix(ci): CANCELLED runがマージを恒久ブロックしないようcancel-in-progressを無効化

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -10,7 +10,9 @@ permissions:
 
 concurrency:
   group: commitlint-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # 実行中 run のキャンセルは CANCELLED check run を commit に残し、
+  # required status checks の判定に混入して PR を恒久的にブロックする（Issue #438）。
+  cancel-in-progress: false
 
 env:
   NODE_VERSION: "24"

--- a/.github/workflows/pr-policy-check.yml
+++ b/.github/workflows/pr-policy-check.yml
@@ -10,7 +10,9 @@ permissions:
 
 concurrency:
   group: pr-policy-check-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # 実行中 run のキャンセルは CANCELLED check run を commit に残し、
+  # required status checks の判定に混入して PR を恒久的にブロックする（Issue #438）。
+  cancel-in-progress: false
 
 jobs:
   pr-policy-check:


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
`pr-policy-check.yml`/`pr-commitlint.yml`の`cancel-in-progress: true`により、ラベル連打などでキャンセルされたrunがCANCELLED check runとしてcommitに残り、必須ステータスチェック判定に混入してPRが恒久的にマージブロックされる問題を解消する。姉妹リポジトリ`kmryst/ticket-c2c-platform`（本workflowの移植先）のPR #60で実際に発生し、PR #62で解消・検証済みの修正を逆輸入する。

## 変更内容（推奨）
- `pr-policy-check.yml`: `cancel-in-progress`を`true`→`false`
- `pr-commitlint.yml`: 同上

## 影響範囲（推奨）
- **対象**: `.github/workflows/pr-policy-check.yml`, `.github/workflows/pr-commitlint.yml`
- **非対象**: `pr-check.yml`（`labeled`/`unlabeled`/`edited`を含まないため対象外）、`security-scan.yml`（PRトリガーでないため対象外）、アプリケーションコード、インフラ

## PRラベル（必須）
- type:bug, area:ci-cd, risk:low, cost:none

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**: 読み取り専用のPRチェックのため並行実行による競合状態のリスクなし。各jobは数秒〜十数秒で完走するため追加コストも無視できる。

</details>

## 可観測性/検証 *条件付き*
このPR自体にラベルを複数連打し、`pr-policy-check.yml`/`pr-commitlint.yml`が全てSUCCESS/正当な結果で完走し、CANCELLED runが残らないこと、`mergeStateStatus`がBLOCKEDにならないことを確認する。

## ロールバック *条件付き*
`cancel-in-progress: false`を`true`に戻すコミットをrevertするだけで元の挙動に戻せる。状態を持たない設定変更のため、データ移行やバックフィルは不要。

## リリース連携（推奨）
- **リリースノート**: 不要

## メモ（レビューポイント）
`kmryst/ticket-c2c-platform`のPR #60/#61/#62と同一の根本原因・同一の修正方針。

Closes #438


Closes #438
