### PR TITLE
fix(ci): DependabotをCommitlintの対象から除外する

### DIFF
--- a/.github/workflows/pr-commitlint.yml
+++ b/.github/workflows/pr-commitlint.yml
@@ -20,6 +20,9 @@ env:
 jobs:
   commitlint:
     name: Commitlint
+    # Dependabot の PR タイトルは可変長で header-max-length に抵触し得る。
+    # フォーマットは Dependabot 側が決定的に生成するため規約強制の対象外とする（Issue #440）。
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
Dependabot生成PRのタイトルは可変長で`commitlint.config.js`の`header-max-length`（100文字）を超えることがあり（PR #437で実際に発生しマージブロック中）、Dependabotのタイトル形式は人間の規律ではなくGitHub/Dependabot側が決定的に生成するため、Commitlintの規約強制対象として意味が薄い。`pr-policy-check.yml`が既に行っている`dependabot[bot]`除外と同じ設計に揃える。

## 変更内容（推奨）
- `pr-commitlint.yml`: `commitlint` jobに`if: github.actor != 'dependabot[bot]'`を追加

## 影響範囲（推奨）
- **対象**: `.github/workflows/pr-commitlint.yml`
- **非対象**: 人間が作成するPRのCommitlint適用は変更なし

## PRラベル（必須）
- type:bug, area:ci-cd, risk:low, cost:none

## 可観測性/検証 *条件付き*
PR #437のCommitlintがskip扱いになり、`mergeStateStatus`がCLEANになることを確認する。

## ロールバック *条件付き*
`if`条件を削除するだけで元の挙動（Dependabotにも適用）に戻せる。状態を持たない設定変更のため、データ移行やバックフィルは不要。

## リリース連携（推奨）
- **リリースノート**: 不要

## メモ（レビューポイント）
`pr-policy-check.yml`の既存の`dependabot[bot]`除外と同一の設計方針。

Closes #440


Closes #440
