### PR TITLE
fix(infra): ALBリスナーdefault_actionの所有権をCodeDeployに委ねる

### DIFF
--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -26,6 +26,12 @@ resource "aws_lb_listener" "http" {
 }
 
 # --- ALB Listener (Production HTTPS) ---
+# default_action の target group 重みは CodeDeploy(ECS Blue/Green) がデプロイごとに
+# 動的に書き換える。Terraform 側で静的管理すると terraform apply が CodeDeploy の
+# 切替結果を巻き戻し、ECS PRIMARY taskset と default_action が不整合になって
+# 「Primary taskset target group must be behind listener」でデプロイが失敗する(Issue #380)。
+# そのため default_action は初期構築時のみ Terraform が設定し、以降は ignore_changes で
+# CodeDeploy に所有権を委ねる(listener rule と同じパターン)。
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.main.arn
   port              = "443"
@@ -38,13 +44,23 @@ resource "aws_lb_listener" "https" {
     forward {
       target_group {
         arn    = aws_lb_target_group.blue.arn
-        weight = 100
+        weight = 100 # 初期Blue 100%
+      }
+      target_group {
+        arn    = aws_lb_target_group.green.arn
+        weight = 0 # 初期Green 0%
       }
     }
+  }
+
+  lifecycle {
+    # CodeDeployによる動的切替を許容(巻き戻さない)
+    ignore_changes = [default_action]
   }
 }
 
 # --- ALB Test Listener (Blue/Green Dark Canary) ---
+# default_action の所有権は aws_lb_listener.https と同様に CodeDeploy に委ねる(Issue #380)
 resource "aws_lb_listener" "test" {
   load_balancer_arn = aws_lb.main.arn
   port              = 8080
@@ -57,9 +73,18 @@ resource "aws_lb_listener" "test" {
     forward {
       target_group {
         arn    = aws_lb_target_group.blue.arn
-        weight = 100
+        weight = 100 # 初期Blue 100%
+      }
+      target_group {
+        arn    = aws_lb_target_group.green.arn
+        weight = 0 # 初期Green 0%
       }
     }
+  }
+
+  lifecycle {
+    # CodeDeployによる動的切替を許容(巻き戻さない)
+    ignore_changes = [default_action]
   }
 }
 


### PR DESCRIPTION
## 目的（推奨）
`deploy.yml`のCodeDeploy Canary/Blue-GreenステップがALBリスナーの`default_action`の所有権競合により`ELASTIC_LOAD_BALANCING_INVALID`(`Primary taskset target group must be behind listener`)で失敗する問題を解消する(#380)。

## 変更内容（推奨）
`terraform/modules/load-balancer/main.tf`の`aws_lb_listener.https`/`aws_lb_listener.test`に`lifecycle { ignore_changes = [default_action] }`を追加し、CodeDeployが動的に書き換えるtarget group重みをTerraformの静的管理対象から外した。既存の`aws_lb_listener_rule.*`の`ignore_changes = [action]`と同じパターン。

## 影響範囲（推奨）
- **対象**: `terraform/modules/load-balancer/main.tf`（`aws_lb_listener.https`/`aws_lb_listener.test`のみ）
- **非対象**: リスナールール(`aws_lb_listener_rule.*`)、target group定義、CodeDeployモジュール、他のTerraformルート

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠（Medium）**: `terraform/**`配下の変更かつALB/CodeDeployのトラフィック切替に関わるため厳密運用。ただし変更は`lifecycle`ブロック追加のみでリソースの再作成は発生しない。

</details>

## 可観測性/検証 *条件付き*
- `terraform fmt -check -recursive`: 差分なし
- `terraform -chdir=terraform/service validate`: Success
- pre-commit（tflint含む）: Passed
- commitlint: Passed
- dev環境での実デプロイ検証（CodeDeploy Canary完走、ALB default_actionとECS PRIMARY tasksetの整合確認）は後続Issue(#445〜#447)実装後、deploy.yml実行時に合わせて実施し、結果をこのIssue/PRのコメントに追記する

## ロールバック
本PRをrevertし、`terraform apply`（`deploy.yml`経由）を再実行すれば、`default_action`はrevert前の静的定義（blue weight=100固定）に戻る。ただし、CodeDeployによるBlue/Green切替直後（green稼働中）にrevertする場合は、revert後のterraform applyがdefault_actionをblueへ巻き戻すため、事前にECS PRIMARY tasksetがblue/greenどちらかを確認し、必要なら先にCodeDeployでblueへロールバックしてからrevertする。

## リリース連携（推奨）
- **リリースノート**: 不要（インフラ内部の設定修正のため）

<details>
<summary>テスト結果/検証手順</summary>

上記「可観測性/検証」参照。dev環境実デプロイでの動作確認は後続作業でまとめて実施予定。

</details>

## メモ（レビューポイント）
- `ignore_changes = [default_action]`により、今後Terraformコード側でdefault_actionを変更しても`terraform apply`では反映されなくなる点に注意（意図的な変更）。初期provisioning時の重み（blue 100% / green 0%）は変更後もコード上残しているが、2回目以降のapplyでは無視される。

Closes #380