### PR TITLE
feat: SLIをmetric mathで計算しSLO burn-rateアラートに接続する

### DIFF
--- a/docs/adr/0026-slo-burn-rate-alerts-for-alb-slis.md
+++ b/docs/adr/0026-slo-burn-rate-alerts-for-alb-slis.md
@@ -1,0 +1,100 @@
+# 0026. ALB系SLIをCloudWatch metric mathで算出しSLO burn-rateアラートに接続する
+
+## ステータス
+
+Accepted
+
+## 日付
+
+2026-07-06
+
+## 決定内容
+
+ALB系のSLI（応答時間・5xxエラー率）を、静的閾値アラームからCloudWatch metric mathベースのratio/比率SLIに再設計し、multi-window multi-burn-rate（fast burn / slow burn の2window）アラームとしてSNSに接続する（`terraform/modules/monitoring/main.tf`）。
+
+- `nestjs-hannibal-3-alb-response-time-high` / `nestjs-hannibal-3-alb-5xx-error-rate-high` を廃止し、以下4つのアラームに置き換える
+  - `nestjs-hannibal-3-slo-error-rate-fast-burn` / `-slow-burn`
+  - `nestjs-hannibal-3-slo-response-time-fast-burn` / `-slow-burn`
+- `canary-error-rate` / `canary-response-time`（CodeDeployのauto rollback接続用）と `ecs-task-stopped`（可用性計上の正本）は対象外とし、従来どおり静的閾値のまま維持する
+- エラー率SLIは `IF(RequestCount(5分合計) >= 最小リクエスト数, (5xx count / RequestCount) * 100, 0)` というratio。低トラフィック時（最小リクエスト数未満）はratioを0%（non-breaching）として扱う
+- 応答時間SLIは `TargetResponseTime(5分平均) / SLO目標値(1秒)` という比率（burn ratio）
+- fast burnはevaluation_periods=1（5分window）、slow burnはevaluation_periods=6（30分window）とし、fast burnはより高い倍率、slow burnはより低い倍率をしきい値にする
+
+## 背景
+
+`docs/operations/slo.md` に文書化済みのSLO目標値（月次可用性99.5%、応答時間1秒未満、5xx rate 0.1%未満）は、これまで静的閾値のCloudWatchアラーム（`alb-response-time-high`: 1秒超過2期間、`alb-5xx-error-rate-high`: 5分合計5件超過）でしか計測・アラートされておらず、SLOの数値目標（%表記のエラー率、応答時間の秒数目標）と実際のアラーム閾値（絶対件数、絶対秒数）が直接対応していなかった。
+
+Google SREの提唱するmulti-window multi-burn-rate alertingは、error budgetの消費速度（burn rate）を短時間窓（fast burn、急激な悪化を早期検知）と長時間窓（slow burn、緩やかな持続的悪化を検知）の2つで監視し、ノイズを抑えつつ実際にSLO違反につながる劣化を検知する手法である。本Issueではこれをこのプロジェクトの規模に合わせて簡略化して採用する。
+
+### 低トラフィック時のratio暴れ
+
+このプロジェクトはdev環境がコスト抑制のため通常destroy済みで運用され（ADR-0008）、常時起動していても実際のリクエスト数は少ない。5xx rateをratio（5xx count / total request count）として計算する場合、5分間のリクエスト数が極端に少ない（例: 2件）と、1件の5xxだけでratioが50%に跳ね上がり、実際には軽微な事象でもfast burnアラームが発報してしまう「ratio暴れ」が発生する。
+
+### 応答時間SLIのratio化における限界
+
+ALB（`AWS/ApplicationELB`）はリクエストごとの遅延ヒストグラムや「しきい値超過リクエスト数」のメトリクスを提供しない。`TargetResponseTime` はAverage/percentile（p50, p90, p99等のExtended Statistics）のみ提供される。したがって、真の意味での「SLO違反リクエストの割合」をmetric mathだけで算出することはできず、本ADRでは平均応答時間とSLO目標値の比（`resp_time / slo_target`）を近似的なburn ratioとして採用する。
+
+## 検討した選択肢
+
+### 低トラフィックガード: 最小リクエスト数未満はratioを0%扱い（採択）
+
+- 長所: 実装がシンプル（metric mathの`IF()`のみで完結し、追加のcomposite alarmや補助リソースが不要）
+- 長所: 低トラフィック時の偽陽性（false positive）burn-rateアラートを防げる
+- 短所: 最小リクエスト数未満の時間帯に実際に5xxが集中していても、ratioとしては検知できない（マスクされる）。ただし、この場合も`HTTPCode_Target_5XX_Count`の絶対値は`runbook.md`のトラブルシュート手順で別途参照可能
+
+### 最小リクエスト数未満はMISSING扱い + `treat_missing_data`で制御
+
+- 長所: 「データなし」を明示的に表現でき、意味論的にはより正確
+- 短所: CloudWatch metric mathの`IF()`はMISSINGを直接返せず、`FILL()`や複数alarmの組み合わせが必要になり実装が複雑化する
+- 短所: このプロジェクトの規模・運用体制に対して過剰な複雑さになる
+
+### 絶対数ベースの閾値を維持し、ratio化しない
+
+- 長所: 実装変更が最小限で済む
+- 短所: Issue #445の受け入れ条件（metric mathでSLIを算出しburn-rateアラートに接続する）を満たさない
+- 短所: SLO目標（%表記）とアラーム閾値（絶対件数）の対応関係が今後も不明瞭なまま残る
+
+### 応答時間SLIをExtended Statistics（p99等）ベースのSLO違反率にする
+
+- 長所: 「p99が1秒を超えた比率」等、より精緻なSLI設計が可能
+- 短所: ALBのExtended StatisticsはCloudWatch上でpercentile値の時系列は取得できるが、「percentileがしきい値を超えたリクエストの割合」を算出するには追加のログベース分析（Athenaでのアクセスログ解析等）が必要で、このIssueのスコープを超える
+- 今後のTODOとして`docs/operations/slo.md`に記載し、必要になった時点で再検討する
+
+### composite alarm（AND条件）でfast burnとslow burnの両方成立時のみ通知
+
+- 長所: Google SREの原典によりノイズが少ない
+- 短所: composite alarmは$0.50/月/個の追加コストが発生する（Issue補足に明記）。本プロジェクトはコスト抑制方針（ADR-0008）を取っており、fast/slow burnそれぞれ独立してSNS通知する設計（受け入れ条件の「2window」）で十分な検知性能を確保できると判断し不採用
+
+## 採択理由
+
+このプロジェクトはdev中心のポートフォリオ運用であり、低トラフィックによるratio暴れを完全に排除する精緻な設計よりも、実装のシンプルさと運用時の理解しやすさを優先する。`IF()`によるガードは、既存の`aws_lb_listener_rule`の`ignore_changes`パターン同様、Terraform/CloudWatchの標準機能のみで完結し、追加リソースやコストを発生させない。
+
+応答時間SLIについても、真のパーセンタイルベースSLIではなく平均値ベースの近似で妥協するが、これは`slo.md`が元々「5分平均`TargetResponseTime`」を目標値として定義していたことと整合しており、既存のSLO定義を壊さずにburn-rate方式へ移行できる。
+
+`canary-error-rate` / `canary-response-time` / `ecs-task-stopped` を対象外としたのは、それぞれCodeDeployの自動ロールバック接続、可用性計上の正本という別の役割を担っており、SLI/SLO再設計の対象にすると既存のデプロイ安全機構に影響するためである。
+
+### `treat_missing_data`のECS系/ALB系不統一について
+
+ECS系アラーム（`ecs-cpu-high`、`ecs-memory-high`、`ecs-task-stopped`）は`treat_missing_data = "breaching"`、ALB系アラーム（今回追加したSLO burn-rateアラームを含む）は`treat_missing_data = "notBreaching"`であり、設定が統一されていない。これは意図的な設計であり、単純な不統一ではないと整理する。
+
+- ECS系: メトリクス欠損はタスクが動いていない（停止・起動失敗）ことを強く示唆するため、`breaching`（アラーム発火）にして異常を見逃さない
+- ALB系: メトリクス欠損は多くの場合「その5分間にリクエストが来なかった」という正常な低トラフィックを意味するため、`notBreaching`にしてfalse alarmを避ける
+
+この非対称性は今回のIssue #445のスコープでは変更せず、既存の設計判断として本ADRに明記するにとどめる。将来的にこの前提が崩れる場合（例: 常時高トラフィックを前提にする本番相当環境を追加する場合）は改めて見直す。
+
+## 影響
+
+- `terraform/modules/monitoring/main.tf`: `alb_response_time_high` / `alb_5xx_error_rate_high` を削除し、`slo_error_rate_fast_burn` / `slo_error_rate_slow_burn` / `slo_response_time_fast_burn` / `slo_response_time_slow_burn` を追加
+- `terraform/modules/monitoring/variables.tf`: SLO burn-rateのしきい値・window・最小リクエスト数を variable化
+- `docs/operations/slo.md`: 「SLI計測とburn-rateアラート」節を追加
+- `docs/operations/runbook.md`: アラーム対応表と該当セクションを新しいアラーム名に更新
+- `docs/operations/monitoring.md`: メトリクス節の記載を更新
+- コスト影響: 新規SNS topic等は追加しないためcost:noneと判断。CloudWatch Alarmの追加数は2個増（旧2個→新4個）だが、Alarmの課金は基本料金内に収まる想定（`cost:small`未満）
+
+## 関連
+
+- [Issue #445](https://github.com/kmryst/terraform-hannibal/issues/445)
+- [SLO](../operations/slo.md)
+- [Runbook](../operations/runbook.md)
+- [ADR 0008: オンデマンド起動 / 通常 destroy 運用を採用する](./0008-on-demand-startup-and-routine-destroy-operation.md)
+- [ADR 0015: ECS デプロイに CodeDeploy Blue/Green を採用する](./0015-adopt-codedeploy-blue-green-for-ecs-deployments.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,3 +65,4 @@
 | [0023](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md) | Accepted | ローカルツール管理に mise を採用し terraform-docs は pre-commit で運用する |
 | [0024](./0024-use-pre-commit-and-ci-dual-layer-for-shell-dockerfile-lint.md) | Deprecated | シェルスクリプト / Dockerfile の lint を pre-commit と CI の二層で実行する |
 | [0025](./0025-pin-github-actions-docker-images-by-tag-and-digest.md) | Accepted | GitHub Actions 内 Docker image を tag と digest で固定する |
+| [0026](./0026-slo-burn-rate-alerts-for-alb-slis.md) | Accepted | ALB系SLIをCloudWatch metric mathで算出しSLO burn-rateアラートに接続する |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -181,10 +181,10 @@ SLO の数値目標は [slo.md](./slo.md) を正本とする。
 
 ### 利用者影響を見るメトリクス
 
-- **レスポンスタイム**: `AWS/ApplicationELB` の `TargetResponseTime`
-- **サーバ側エラー**: `AWS/ApplicationELB` の `HTTPCode_Target_5XX_Count`
+- **レスポンスタイム**: `AWS/ApplicationELB` の `TargetResponseTime`。SLI/SLO burn-rateアラーム（`nestjs-hannibal-3-slo-response-time-fast-burn` / `-slow-burn`）は [slo.md](./slo.md) 参照
+- **サーバ側エラー**: `AWS/ApplicationELB` の `HTTPCode_Target_5XX_Count`。SLI/SLO burn-rateアラーム（`nestjs-hannibal-3-slo-error-rate-fast-burn` / `-slow-burn`）は [slo.md](./slo.md) 参照
 - **稼働状態**: ECS `RunningTaskCount`、ALB target health、CodeDeploy deployment status
-- **デプロイ健全性**: `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time`
+- **デプロイ健全性**: `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time`（CodeDeploy auto rollback専用。SLI burn-rateアラームとは別系統で維持）
 
 ### インフラ健全性を見るメトリクス
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -47,8 +47,10 @@ aws logs tail "$LOG_GROUP" \
 | `nestjs-hannibal-3-ecs-task-stopped`                      | ECS task 停止または running count 異常の疑い | ECS service と stopped task reason を確認する                        |
 | `nestjs-hannibal-3-rds-cpu-high`                          | RDS CPU 5分平均が 60% 超過                   | slow query、接続増加、アプリ retry を確認する                        |
 | `nestjs-hannibal-3-rds-connections-high`                  | RDS connections が 12 超過                   | connection leak、pool 設定、再試行増加を確認する                     |
-| `nestjs-hannibal-3-alb-response-time-high`                | ALB target response time が 1秒超過          | ECS/RDS/外部依存の遅延を切り分ける                                   |
-| `nestjs-hannibal-3-alb-5xx-error-rate-high`               | ALB target 5xx が 5分合計 5件超過            | ECS logs と直近 deploy を確認する                                    |
+| `nestjs-hannibal-3-slo-response-time-fast-burn`           | 応答時間SLI(平均/SLO目標比)が5分でSLO目標の2倍超過 | ECS/RDS/外部依存の遅延を切り分ける                                   |
+| `nestjs-hannibal-3-slo-response-time-slow-burn`           | 応答時間SLIが30分持続でSLO目標の1.2倍超過    | ECS/RDS/外部依存の遅延を切り分ける                                   |
+| `nestjs-hannibal-3-slo-error-rate-fast-burn`               | 5xx rate SLI(ratio)が5分でerror budgetの14.4倍超過 | ECS logs と直近 deploy を確認する                                    |
+| `nestjs-hannibal-3-slo-error-rate-slow-burn`               | 5xx rate SLIが30分持続でerror budgetの3倍超過 | ECS logs と直近 deploy を確認する                                    |
 | `nestjs-hannibal-3-canary-error-rate`                     | canary 中の 5xx 増加                         | CodeDeploy auto rollback の状態を確認する                            |
 | `nestjs-hannibal-3-canary-response-time`                  | canary 中の response time 悪化               | CodeDeploy auto rollback の状態を確認する                            |
 | `nestjs-hannibal-3-cloudtrail-root-account-usage`         | root account 利用検知                        | 正当性確認、不要なら認証情報保護と MFA 確認を行う                    |
@@ -114,19 +116,25 @@ aws ecs describe-tasks \
 4. connections だけが高い場合は connection pool 解放漏れや retry 設定を確認する。
 5. 継続する場合は query 調査、index、pool 上限、DB instance class 見直しを Issue 化する。
 
-### ALB response time high
+### 応答時間SLI burn-rate（fast/slow burn）
+
+`nestjs-hannibal-3-slo-response-time-fast-burn` / `nestjs-hannibal-3-slo-response-time-slow-burn` は、CloudWatch metric mathで算出した「平均TargetResponseTime / SLO目標(1秒)」の比率を見る。fast burnは短時間の急激な悪化、slow burnは持続的な悪化を検知する。設計判断は [ADR-0026](../adr/0026-slo-burn-rate-alerts-for-alb-slis.md) を参照。
 
 1. ALB `TargetResponseTime`、`HTTPCode_Target_5XX_Count`、ECS CPU / memory、RDS CPU / connections を同じ時間帯で見る。
 2. ECS / RDS のどちらも正常なら、アプリケーションログで遅い endpoint や GraphQL query を確認する。
 3. canary / bluegreen 中なら CodeDeploy の alarm と deployment status を確認する。
 4. 利用者影響が継続する場合は rollback を優先する。
+5. fast burnのみ発報している場合は短時間のスパイクの可能性があるため、slow burnの発報有無で持続性を確認する。
 
-### ALB 5xx high
+### 5xx rate SLI burn-rate（fast/slow burn）
+
+`nestjs-hannibal-3-slo-error-rate-fast-burn` / `nestjs-hannibal-3-slo-error-rate-slow-burn` は、CloudWatch metric mathで算出した「5xx count / RequestCount」のratio(%)を見る。5分間のリクエスト数が少ない場合はratioを0%扱いにする低トラフィックガードがある（[ADR-0026](../adr/0026-slo-burn-rate-alerts-for-alb-slis.md)参照）。
 
 1. ECS logs で exception、DB 接続エラー、起動失敗を確認する。
 2. ALB target health を確認し、unhealthy target が増えていないか見る。
 3. 直近 deploy がある場合は CodeDeploy deployment status を確認する。
 4. canary 中の 5xx であれば auto rollback を待つ。止まらない場合は手動停止する。
+5. 低トラフィック時（リクエスト数が少ない時間帯）はratioが0%扱いになり発報しないことがあるため、絶対数（`HTTPCode_Target_5XX_Count`）も合わせて確認する。
 
 ```bash
 for tg in nestjs-hannibal-3-blue-tg nestjs-hannibal-3-green-tg; do

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -32,10 +32,28 @@
 
 | 項目             | 目標                                                                                                         | 既存アラートとの関係                                                                                                 |
 | ---------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| レスポンスタイム | 起動期間中の 5分平均 `TargetResponseTime` を 1秒未満に保つ。通常時の運用目安は 200ms 未満                    | `nestjs-hannibal-3-alb-response-time-high` が 1秒超過を 2期間連続で検知する                                          |
-| エラー率         | 起動期間中の target 5xx rate を 0.1% 未満に保つ。低トラフィック時は 5分あたり 5件以上の 5xx を調査対象にする | `nestjs-hannibal-3-alb-5xx-error-rate-high` が 5分合計 5件超過を検知する                                             |
-| 稼働率           | 起動期間中の月次可用性 99.5% 以上を目標にする                                                                | `nestjs-hannibal-3-ecs-task-stopped` または `nestjs-hannibal-3-alb-5xx-error-rate-high` が ALARM 状態だった時間の合計を月次停止時間として扱う。本環境は destroy/deploy 運用のため外形監視（CloudWatch Synthetics 等）は導入していない。本番相当環境では Synthetics Canary による black-box 監視を追加する |
+| レスポンスタイム | 起動期間中の 5分平均 `TargetResponseTime` を 1秒未満に保つ。通常時の運用目安は 200ms 未満                    | `nestjs-hannibal-3-slo-response-time-fast-burn` / `nestjs-hannibal-3-slo-response-time-slow-burn` がburn rateを検知する（詳細は「SLI計測とburn-rateアラート」節） |
+| エラー率         | 起動期間中の target 5xx rate を 0.1% 未満に保つ。低トラフィック時は 5分あたり 5件以上の 5xx を調査対象にする | `nestjs-hannibal-3-slo-error-rate-fast-burn` / `nestjs-hannibal-3-slo-error-rate-slow-burn` がburn rateを検知する（詳細は「SLI計測とburn-rateアラート」節） |
+| 稼働率           | 起動期間中の月次可用性 99.5% 以上を目標にする                                                                | `nestjs-hannibal-3-ecs-task-stopped` または `nestjs-hannibal-3-slo-error-rate-slow-burn` が ALARM 状態だった時間の合計を月次停止時間として扱う。本環境は destroy/deploy 運用のため外形監視（CloudWatch Synthetics 等）は導入していない。本番相当環境では Synthetics Canary による black-box 監視を追加する |
 | Canary 安全性    | canary 中は 1分単位で 5xx と応答時間を監視し、悪化時は CodeDeploy の auto rollback を優先する                | `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time` を CodeDeploy alarm として利用する。canary 用応答時間アラームの閾値は 2秒（定常 SLO の 1秒より緩め）。デプロイ時のコンテナ起動・接続プール初期化による一時的な遅延と実際の品質劣化を切り分けるため意図的に乖離させている |
+
+## SLI計測とburn-rateアラート
+
+ALB系（応答時間 / 5xx）のSLIは、CloudWatch metric mathで算出したうえでmulti-window multi-burn-rateアラーム（fast burn / slow burn）としてSNSに接続する（`terraform/modules/monitoring/main.tf`）。`canary-error-rate` / `canary-response-time`（CodeDeployのauto rollback用）と `ecs-task-stopped`（可用性計上の正本）は本方式の対象外として、従来の静的閾値アラームのまま維持する。
+
+### エラー率SLI
+
+- `error_ratio = IF(RequestCount(5分合計) >= 最小リクエスト数, (5xx count / RequestCount) * 100, 0)`
+- 最小リクエスト数未満の5分間はratioを0%（non-breaching）として扱う。低トラフィック時のratio暴れ対策の設計判断は [ADR-0026](../adr/0026-slo-burn-rate-alerts-for-alb-slis.md) を参照
+- fast burn: 5分window、error budget（0.1%）の14.4倍（1.44%）超過で発報
+- slow burn: 30分window（5分x6期間）、error budget（0.1%）の3倍（0.3%）超過で発報
+
+### 応答時間SLI
+
+- `resp_ratio = TargetResponseTime(5分平均) / SLO目標値(1秒)`
+- ALBはリクエストごとの遅延ヒストグラムを提供しないため、平均応答時間としきい値の比をburn rateの近似として扱う。この近似の限界と代替案は [ADR-0026](../adr/0026-slo-burn-rate-alerts-for-alb-slis.md) を参照
+- fast burn: 5分window、比が2.0（平均応答時間がSLO目標の2倍）超過で発報
+- slow burn: 30分window、比が1.2（平均応答時間がSLO目標の1.2倍）超過で発報
 
 ## 計測方法
 

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -142,52 +142,186 @@ resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
   }
 }
 
-# --- ALB Monitoring ---
-# ALB レスポンス時間監視（実務レベル: 1秒）
-resource "aws_cloudwatch_metric_alarm" "alb_response_time_high" {
-  alarm_name          = "${var.project_name}-alb-response-time-high"
+# --- ALB Monitoring: SLO burn-rate alarms (ADR-0026) ---
+# docs/operations/slo.md のSLI/SLO(応答時間1秒未満、5xx rate 0.1%未満)をCloudWatch metric mathで算出し、
+# multi-window multi-burn-rate(fast burn / slow burn)でSNSに接続する。
+# canary-error-rate/canary-response-time(CodeDeploy auto rollback用)とecs-task-stopped(可用性計上の正本)は対象外として維持する。
+
+# エラー率SLI: 5xx count / total request count の ratio(%)。
+# 低トラフィック時にratioが暴れるのを避けるため、5分間のリクエスト数が
+# var.slo_min_request_count 未満の場合は non-breaching(0%)として扱う(ADR-0026参照)。
+resource "aws_cloudwatch_metric_alarm" "slo_error_rate_fast_burn" {
+  alarm_name          = "${var.project_name}-slo-error-rate-fast-burn"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "TargetResponseTime"
-  namespace           = "AWS/ApplicationELB"
-  period              = "300"
-  statistic           = "Average"
-  threshold           = "1"
-  alarm_description   = "ALB response time is too high - poor user experience"
+  evaluation_periods  = 1
+  threshold           = var.slo_error_budget_percent * var.slo_error_rate_fast_burn_multiplier
+  alarm_description   = "Error budget fast burn: 5xx rate SLI is consuming the monthly error budget rapidly (5min window)"
   alarm_actions       = [aws_sns_topic.alerts.arn]
   ok_actions          = [aws_sns_topic.alerts.arn]
   treat_missing_data  = "notBreaching"
 
-  dimensions = {
-    LoadBalancer = var.alb_arn_suffix
+  metric_query {
+    id          = "e5xx"
+    return_data = false
+    metric {
+      metric_name = "HTTPCode_Target_5XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "ereq"
+    return_data = false
+    metric {
+      metric_name = "RequestCount"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "error_ratio"
+    label       = "5xx error rate SLI (%)"
+    expression  = "IF(ereq >= ${var.slo_min_request_count}, (e5xx / ereq) * 100, 0)"
+    return_data = true
   }
 
   tags = {
-    Name = "${var.project_name}-alb-response-time-alarm"
+    Name = "${var.project_name}-slo-error-rate-fast-burn-alarm"
   }
 }
 
-# ALB 5xxエラー率監視（実務レベル: 1%）
-resource "aws_cloudwatch_metric_alarm" "alb_5xx_error_rate_high" {
-  alarm_name          = "${var.project_name}-alb-5xx-error-rate-high"
+resource "aws_cloudwatch_metric_alarm" "slo_error_rate_slow_burn" {
+  alarm_name          = "${var.project_name}-slo-error-rate-slow-burn"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = "5"
-  alarm_description   = "ALB 5xx error rate is too high - server errors detected"
+  evaluation_periods  = 6 # 300s x 6 = 30分window
+  threshold           = var.slo_error_budget_percent * var.slo_error_rate_slow_burn_multiplier
+  alarm_description   = "Error budget slow burn: 5xx rate SLI is sustained above the SLO over a longer window (30min)"
   alarm_actions       = [aws_sns_topic.alerts.arn]
   ok_actions          = [aws_sns_topic.alerts.arn]
   treat_missing_data  = "notBreaching"
 
-  dimensions = {
-    LoadBalancer = var.alb_arn_suffix
+  metric_query {
+    id          = "e5xx"
+    return_data = false
+    metric {
+      metric_name = "HTTPCode_Target_5XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "ereq"
+    return_data = false
+    metric {
+      metric_name = "RequestCount"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "error_ratio"
+    label       = "5xx error rate SLI (%)"
+    expression  = "IF(ereq >= ${var.slo_min_request_count}, (e5xx / ereq) * 100, 0)"
+    return_data = true
   }
 
   tags = {
-    Name = "${var.project_name}-alb-5xx-alarm"
+    Name = "${var.project_name}-slo-error-rate-slow-burn-alarm"
+  }
+}
+
+# 応答時間SLI: 平均TargetResponseTime / SLO目標値(1秒) の比率(burn ratio)。
+# ALBはリクエストごとの遅延ヒストグラムを提供しないため、平均応答時間としきい値の比を
+# burn rateの近似として扱う(ADR-0026で限界と代替案を記載)。
+resource "aws_cloudwatch_metric_alarm" "slo_response_time_fast_burn" {
+  alarm_name          = "${var.project_name}-slo-response-time-fast-burn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = var.slo_response_time_fast_burn_multiplier
+  alarm_description   = "Error budget fast burn: response time SLI is far above the SLO target (5min window)"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "resp_time"
+    return_data = false
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Average"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "resp_ratio"
+    label       = "Response time SLI (burn ratio)"
+    expression  = "resp_time / ${var.slo_response_time_target_seconds}"
+    return_data = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-slo-response-time-fast-burn-alarm"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "slo_response_time_slow_burn" {
+  alarm_name          = "${var.project_name}-slo-response-time-slow-burn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 6 # 300s x 6 = 30分window
+  threshold           = var.slo_response_time_slow_burn_multiplier
+  alarm_description   = "Error budget slow burn: response time SLI is sustained above the SLO target over a longer window (30min)"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "resp_time"
+    return_data = false
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Average"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id          = "resp_ratio"
+    label       = "Response time SLI (burn ratio)"
+    expression  = "resp_time / ${var.slo_response_time_target_seconds}"
+    return_data = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-slo-response-time-slow-burn-alarm"
   }
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -33,3 +33,48 @@ variable "alb_arn_suffix" {
   description = "ARN suffix of the Application Load Balancer"
   type        = string
 }
+
+# --- SLO burn-rate alarm settings (ADR-0026) ---
+# 数値の正本は docs/operations/slo.md。ここでは metric math 用のしきい値・window を定義する。
+
+variable "slo_error_budget_percent" {
+  description = "SLOで許容する5xx error rateの目標値(%)。docs/operations/slo.mdの月次エラー率0.1%が正本"
+  type        = number
+  default     = 0.1
+}
+
+variable "slo_error_rate_fast_burn_multiplier" {
+  description = "fast burn(短時間窓)アラームのerror budget消費倍率。Google SRE本のmulti-window multi-burn-rate例に準拠(約14.4x)"
+  type        = number
+  default     = 14.4
+}
+
+variable "slo_error_rate_slow_burn_multiplier" {
+  description = "slow burn(長時間窓)アラームのerror budget消費倍率"
+  type        = number
+  default     = 3
+}
+
+variable "slo_min_request_count" {
+  description = "error rate SLIをratioとして評価するために必要な最小リクエスト数(5分間)。これ未満の場合はratioの暴れを避けるためnon-breaching扱いにする(ADR-0026参照)"
+  type        = number
+  default     = 20
+}
+
+variable "slo_response_time_target_seconds" {
+  description = "応答時間SLOの目標値(秒)。docs/operations/slo.mdの1秒未満が正本"
+  type        = number
+  default     = 1
+}
+
+variable "slo_response_time_fast_burn_multiplier" {
+  description = "response time SLIのfast burnしきい値倍率(平均応答時間がSLO目標の何倍で発報するか)"
+  type        = number
+  default     = 2
+}
+
+variable "slo_response_time_slow_burn_multiplier" {
+  description = "response time SLIのslow burnしきい値倍率"
+  type        = number
+  default     = 1.2
+}


### PR DESCRIPTION
## 目的（推奨）
`docs/operations/slo.md`に文書化済みのSLO目標値（月次可用性99.5%、応答時間1秒未満、5xx rate 0.1%未満）を、静的閾値アラームではなく実際に計測・アラート可能なSLIとして接続する(#445)。

## 変更内容（推奨）
- ALB系（応答時間/5xx）の静的閾値アラーム`alb-response-time-high`/`alb-5xx-error-rate-high`を廃止し、CloudWatch metric mathベースのSLI(ratio)を算出するmulti-window multi-burn-rateアラーム4つ（`slo-error-rate-fast-burn`/`-slow-burn`、`slo-response-time-fast-burn`/`-slow-burn`）に置き換え
- `canary-error-rate`/`canary-response-time`（CodeDeploy auto rollback接続用）と`ecs-task-stopped`（可用性計上の正本）は対象外として維持
- 低トラフィック時のratio暴れ対策（最小リクエスト数未満はnon-breaching扱い）と、ALBが提供しないリクエスト単位ヒストグラムの制約下での応答時間SLI近似設計をADR-0026として記録
- `docs/operations/slo.md`/`runbook.md`/`monitoring.md`を新しいアラーム構成に更新

## 影響範囲（推奨）
- **対象**: `terraform/modules/monitoring/main.tf`、`terraform/modules/monitoring/variables.tf`、`docs/operations/slo.md`、`docs/operations/runbook.md`、`docs/operations/monitoring.md`、`docs/adr/0026-*.md`、`docs/adr/README.md`
- **非対象**: ECS系/RDS系アラーム、`canary-error-rate`/`canary-response-time`/`ecs-task-stopped`、CloudWatch Dashboard構成、SNS topic

<details>
<summary>影響メモ（必要時のみ）</summary>

**コスト根拠（small）**: CloudWatch Alarmが2個→4個に増加。metric math式を含むアラームでも基本料金内に収まる想定だが、念のためcost:smallとした。
**リスク根拠（Medium）**: `terraform/**`配下の変更かつ本番相当の監視・アラート経路に関わるため厳密運用。

</details>

## 可観測性/検証 *条件付き*
- `terraform fmt -check -recursive`: 差分なし
- `terraform -chdir=terraform/service validate`: Success
- pre-commit（tflint含む）: Passed
- commitlint: Passed
- dev環境での実デプロイ検証（新しい4アラームがCloudWatchに作成されること、metric math式が期待通り評価されること）は後続Issue(#446/#447)実装後、deploy.yml実行時に合わせて実施し、結果をこのIssue/PRのコメントに追記する

## ロールバック
本PRをrevertし、`terraform apply`（`deploy.yml`経由）を再実行すれば、新設した4アラームが削除され、旧`alb-response-time-high`/`alb-5xx-error-rate-high`の静的閾値アラームに戻る。SNS topic・ECS/RDS系アラームには影響しないため、revertによるサービス影響はない。

## リリース連携（推奨）
- **リリースノート**: 不要（インフラ内部の監視設計変更のため）

<details>
<summary>テスト結果/検証手順</summary>

上記「可観測性/検証」参照。dev環境実デプロイでの動作確認は後続作業でまとめて実施予定。

</details>

## メモ（レビューポイント）
- 応答時間SLIは真のパーセンタイルベースSLO違反率ではなく、「平均応答時間/SLO目標値」の近似比率を採用している。設計判断の詳細と限界はADR-0026を参照。
- `treat_missing_data`がECS系(breaching)とALB系(notBreaching)で異なる点は意図的な設計であり、ADR-0026にその理由を明記した。

Closes #445