### PR TITLE
docs: foundation applyのAI実行例外をCLAUDE.mdに明記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,11 +146,13 @@ done
 
 | ディレクトリ | 用途 | apply/destroy |
 |---|---|---|
-| `terraform/foundation/` | 基盤 IAM・OIDC 等（恒久リソース） | PR マージ後に人間が手動実行。`state rm` しない |
+| `terraform/foundation/` | 基盤 IAM・OIDC 等（恒久リソース） | 原則は人間が手動実行。`state rm` しない |
 | `terraform/network/` | VPC・subnet・Security Group | `deploy.yml` / `destroy.yml` から実行 |
 | `terraform/database/` | RDS PostgreSQL | `deploy.yml` / `destroy.yml` から実行 |
 | `terraform/service/` | ECS・ALB・CodeDeploy・monitoring | `deploy.yml` / `destroy.yml` から実行 |
 | `terraform/cdn/` | CloudFront・S3・DNS | `deploy.yml` / `destroy.yml` から実行 |
+
+`terraform/foundation/` の apply は原則ユーザーが手動実行する。ただし、ユーザーが明示的に許可した場合は、AI が `terraform -chdir=terraform/foundation apply` を実行してよい。事前の包括的な許可でよく、実行のたびに個別の許可を得る必要はない。
 
 ### state 管理方針
 


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
`terraform/foundation/` のapplyは「人間が手動実行する」原則だったが、ユーザーの明示的な包括許可があればAIが実行してよい例外を明記する。

## 変更内容（推奨）
`CLAUDE.md`の「ディレクトリ別の方針」表とその直後に、foundation applyのAI実行例外を追記。

## 影響範囲（推奨）
- **対象**: `CLAUDE.md`のみ
- **非対象**: 実際のterraform構成・コード

## PRラベル（必須）
- type:docs
- area:docs
- risk:low
- cost:none

## 可観測性/検証
No-op（適用外、ドキュメントのみの変更）

## ロールバック
軽運用PR（ドキュメントのみ）のため不要。差し戻す場合は本PRをrevertするのみ。

## リリース連携（推奨）
- **リリースノート**: 不要

## メモ（レビューポイント）
ユーザー本人の明示的な発言（「apply も許可する」「今許可する」「許可する」「君がやれ。すべて許可する」等）を受けての運用ルール変更。

Closes #452


Closes #452
