### PR TITLE
fix(iam): fis:CreateExperimentTemplateにFIS actionリソースへの権限を追加する

### DIFF
--- a/terraform/foundation/iam.tf
+++ b/terraform/foundation/iam.tf
@@ -779,6 +779,10 @@ resource "aws_iam_policy" "hannibal_cicd_policy_deploy" {
         # aws_fis_experiment_templateをapplyするための権限(Issue #454)。
         # HannibalCICDBoundaryのfis:*はceilingに過ぎず、実権限はこのpolicyで付与する。
         # 実験の実行権限自体(ecs:StopTask等)はHannibalFISRole-Dev側(Issue #446)に限定済み。
+        # CreateExperimentTemplate/UpdateExperimentTemplateは、テンプレート内で参照する
+        # FIS actionリソース(ここではaws:ecs:stop-task)についても同じIAM actionでの
+        # 許可を要求する(AWSのマルチリソースAPI評価。Issue #456。#454時点では
+        # experiment-templateリソースのみ許可しており見落としていた)。
         Sid    = "FISExperimentTemplateManagement"
         Effect = "Allow"
         Action = [
@@ -791,7 +795,10 @@ resource "aws_iam_policy" "hannibal_cicd_policy_deploy" {
           "fis:UntagResource",
           "fis:ListTagsForResource"
         ]
-        Resource = "arn:aws:fis:ap-northeast-1:${data.aws_caller_identity.current.account_id}:experiment-template/*"
+        Resource = [
+          "arn:aws:fis:ap-northeast-1:${data.aws_caller_identity.current.account_id}:experiment-template/*",
+          "arn:aws:fis:ap-northeast-1:${data.aws_caller_identity.current.account_id}:action/aws:ecs:stop-task"
+        ]
       },
       {
         Sid      = "IAMPassRoleForFISOnly"


### PR DESCRIPTION
## 目的（推奨）
PR #455の修正後も`deploy.yml`（canary、run 28801643140）が同じ`AccessDeniedException`で失敗した問題を修正する(#456)。

## 変更内容（推奨）
AWS公式ドキュメント（[Create an experiment template for a specific action](https://docs.aws.amazon.com/fis/latest/userguide/security_iam_id-based-policy-examples.html)）で確認した通り、`fis:CreateExperimentTemplate`はexperiment-templateリソースとテンプレートが参照するFIS actionリソースの両方に同一IAM actionでの許可を要求するマルチリソースAPIだった。`FISExperimentTemplateManagement`statementのResourceに`arn:aws:fis:ap-northeast-1:<account>:action/aws:ecs:stop-task`を追加した。

## 影響範囲（推奨）
- **対象**: `terraform/foundation/iam.tf`（`hannibal_cicd_policy_deploy`のみ、Resource追加のみ）
- **非対象**: 他のCICD権限、HannibalFISRole-Dev

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠（High）**: `terraform/foundation`のIAM権限追加のため。ただし`aws:ecs:stop-task` action ARNへの参照許可のみで、既存権限を変更しない。

</details>

## 可観測性/検証 *条件付き*
- `terraform fmt -check -recursive`: 差分なし
- `terraform -chdir=terraform/foundation validate`: Success
- pre-commit（tflint、terraform-docs含む）: Passed
- commitlint: Passed
- AWS公式ドキュメントの実例と完全に一致するResource構成であることを確認済み
- マージ後、foundation apply → deploy.yml再実行でFIS実験テンプレートのapply成功を確認する

## ロールバック
本PRをrevertし、`terraform apply`を再実行すれば追加したResource ARNが削除される。他の権限には影響しない。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

上記「可観測性/検証」参照。

</details>

## メモ（レビューポイント）
- PR #455時点でも同じ轍を踏まないよう、今回はAWS公式ドキュメントの実例で完全一致を確認してから実装した

Closes #456