### PR TITLE
feat(infra): Synthetics canaryのtime-based availability SLIをアラームに接続する

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -185,6 +185,7 @@ SLO の数値目標は [slo.md](./slo.md) を正本とする。
 - **サーバ側エラー**: `AWS/ApplicationELB` の `HTTPCode_Target_5XX_Count`。SLI/SLO burn-rateアラーム（`nestjs-hannibal-3-slo-error-rate-fast-burn` / `-slow-burn`）は [slo.md](./slo.md) 参照
 - **稼働状態**: ECS `RunningTaskCount`、ALB target health、CodeDeploy deployment status
 - **デプロイ健全性**: `nestjs-hannibal-3-canary-error-rate` と `nestjs-hannibal-3-canary-response-time`（CodeDeploy auto rollback専用。SLI burn-rateアラームとは別系統で維持）
+- **ユーザージャーニー外形監視**: `CloudWatchSynthetics` namespaceの`SuccessPercent`（canary名`hannibal-canary`）。time-based availability SLIとして1時間平均を見る`nestjs-hannibal-3-synthetics-availability-low`アラームを追加した（ADR-0030、Issue #467）
 
 ### インフラ健全性を見るメトリクス
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -53,6 +53,7 @@ aws logs tail "$LOG_GROUP" \
 | `nestjs-hannibal-3-slo-error-rate-slow-burn`               | 5xx rate SLIが30分持続でerror budgetの3倍超過 | ECS logs と直近 deploy を確認する                                    |
 | `nestjs-hannibal-3-canary-error-rate`                     | canary 中の 5xx 増加                         | CodeDeploy auto rollback の状態を確認する                            |
 | `nestjs-hannibal-3-canary-response-time`                  | canary 中の response time 悪化               | CodeDeploy auto rollback の状態を確認する                            |
+| `nestjs-hannibal-3-synthetics-availability-low`           | Synthetics canaryのtime-based availabilityが1時間平均で目標(99.5%)未満、またはcanaryが1時間結果を報告していない | フロントエンド/ALB/GraphQLのどのステップで失敗しているか、canaryの実行ログとS3 artifactを確認する |
 | `nestjs-hannibal-3-cloudtrail-root-account-usage`         | root account 利用検知                        | 正当性確認、不要なら認証情報保護と MFA 確認を行う                    |
 | `nestjs-hannibal-3-cloudtrail-iam-policy-change`          | IAM policy 変更検知                          | 変更者、変更内容、Issue / PR との対応を確認する                      |
 | `nestjs-hannibal-3-cloudtrail-configuration-change`       | CloudTrail 設定変更検知                      | 監査ログ停止や改ざん意図がないか確認する                             |
@@ -156,6 +157,23 @@ aws deploy list-deployments \
   --application-name nestjs-hannibal-3-app \
   --deployment-group-name nestjs-hannibal-3-dg \
   --max-items 5 \
+  --region ap-northeast-1
+```
+
+### Synthetics canary availability alarm
+
+`nestjs-hannibal-3-synthetics-availability-low` は、ユーザージャーニー外形監視canary（`hannibal-canary`）の`SuccessPercent`を1時間平均で見て、time-based availability目標(99.5%)を下回るとALARMになる（ADR-0030、Issue #467）。`treat_missing_data = breaching`のため、canary自体が1時間結果を報告しない場合もALARMになる。
+
+1. CloudWatch Synthetics コンソールで`hannibal-canary`の直近の実行結果（Pass/Fail）とステップ別の失敗理由を確認する。
+2. どのステップ（`frontend-delivery` / `alb-health-check` / `graphql-read-query`）で失敗しているかを特定する。
+3. S3 artifactバケット（`nestjs-hannibal-3-synthetics-canary-artifacts`）のHARファイル・スクリーンショットで詳細を確認する。
+4. `alb-health-check` / `graphql-read-query`が失敗する場合は、ALB origin-verifyヘッダー用secret（Secrets Manager）の値とALB listener ruleの整合を確認する。
+5. canary自体が実行されていない場合は、canary実行roleの権限とLambda実行エラーを確認する。
+
+```bash
+aws synthetics get-canary-runs \
+  --name hannibal-canary \
+  --max-results 5 \
   --region ap-northeast-1
 ```
 

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -325,6 +325,36 @@ resource "aws_cloudwatch_metric_alarm" "slo_response_time_slow_burn" {
   }
 }
 
+# --- Synthetics canary availability (time-based availability SLI, ADR-0030) ---
+# canaryの成功/失敗はSuccessPercent(0 or 100)の二値でしか得られないため、
+# ratioではなく1時間平均をtime-based availabilityの近似として扱う(ADR-0030参照)。
+# synthetics_canary_nameが空文字の場合(canary無効時)はアラームを作成しない。
+resource "aws_cloudwatch_metric_alarm" "synthetics_availability" {
+  count               = var.synthetics_canary_name != "" ? 1 : 0
+  alarm_name          = "${var.project_name}-synthetics-availability-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  period              = 3600 # 1時間平均。低頻度実行のSuccessPercentのratio暴れを避ける(ADR-0030)
+  metric_name         = "SuccessPercent"
+  namespace           = "CloudWatchSynthetics"
+  statistic           = "Average"
+  threshold           = var.synthetics_availability_target_percent
+  alarm_description   = "User-journey canary time-based availability dropped below the SLO target over the last hour"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  # canaryが1時間まったく実行結果を報告しない場合、canary自体(Lambda実行)が壊れている可能性が高いため
+  # ECS系アラームと同様にbreachingとして扱う(ADR-0026の非対称設計を踏襲、ALB系のnotBreachingとは異なる)
+  treat_missing_data = "breaching"
+
+  dimensions = {
+    CanaryName = var.synthetics_canary_name
+  }
+
+  tags = {
+    Name = "${var.project_name}-synthetics-availability-alarm"
+  }
+}
+
 # --- Canary Deployment Monitoring ---
 # カナリアデプロイ用エラー率監視（5%以上でロールバック）
 resource "aws_cloudwatch_metric_alarm" "canary_error_rate" {

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -22,3 +22,8 @@ output "slo_error_rate_fast_burn_alarm_arn" {
   description = "ARN of the SLO error-rate fast-burn alarm (used as an AWS FIS Game Day experiment stop condition, Issue #447)"
   value       = aws_cloudwatch_metric_alarm.slo_error_rate_fast_burn.arn
 }
+
+output "synthetics_availability_alarm_name" {
+  description = "Name of the Synthetics canary time-based availability alarm. null when the canary is disabled (ADR-0030, Issue #467)"
+  value       = var.synthetics_canary_name != "" ? aws_cloudwatch_metric_alarm.synthetics_availability[0].alarm_name : null
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -78,3 +78,17 @@ variable "slo_response_time_slow_burn_multiplier" {
   type        = number
   default     = 1.2
 }
+
+# --- Synthetics canary availability (ADR-0030, Issue #467) ---
+
+variable "synthetics_canary_name" {
+  description = "Synthetics canaryの名前。空文字の場合は稼働率アラームを作成しない(canary無効時)"
+  type        = string
+  default     = ""
+}
+
+variable "synthetics_availability_target_percent" {
+  description = "canaryのtime-based availability目標値(%)。docs/operations/slo.mdの稼働率SLOが正本"
+  type        = number
+  default     = 99.5
+}

--- a/terraform/service/README.md
+++ b/terraform/service/README.md
@@ -81,6 +81,7 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 | <a name="output_green_target_group_name"></a> [green\_target\_group\_name](#output\_green\_target\_group\_name) | Green target group name |
 | <a name="output_slo_error_rate_fast_burn_alarm_arn"></a> [slo\_error\_rate\_fast\_burn\_alarm\_arn](#output\_slo\_error\_rate\_fast\_burn\_alarm\_arn) | ARN of the SLO error-rate fast-burn alarm (consumed by terraform/observability as an AWS FIS stop condition, Issue #458) |
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | SNS topic ARN for alarm notifications |
+| <a name="output_synthetics_availability_alarm_name"></a> [synthetics\_availability\_alarm\_name](#output\_synthetics\_availability\_alarm\_name) | Name of the Synthetics canary time-based availability alarm (ADR-0030, Issue #467). null when disabled |
 | <a name="output_synthetics_canary_arn"></a> [synthetics\_canary\_arn](#output\_synthetics\_canary\_arn) | ARN of the Synthetics user-journey canary. null when disabled |
 | <a name="output_synthetics_canary_artifacts_bucket_name"></a> [synthetics\_canary\_artifacts\_bucket\_name](#output\_synthetics\_canary\_artifacts\_bucket\_name) | S3 bucket name storing Synthetics canary run artifacts. null when disabled |
 | <a name="output_synthetics_canary_name"></a> [synthetics\_canary\_name](#output\_synthetics\_canary\_name) | Name of the Synthetics user-journey canary (ADR-0030, Issue #465). null when disabled |

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -77,6 +77,10 @@ module "monitoring" {
   ecs_cluster_name = module.ecs.cluster_name
   rds_instance_id  = data.terraform_remote_state.database.outputs.db_instance_id
   alb_arn_suffix   = module.load_balancer.alb_arn
+
+  # Synthetics canaryのtime-based availability SLI(ADR-0030, Issue #467)。
+  # enable_synthetics_canary=falseの場合は空文字を渡し、monitoringモジュール側でアラーム自体を作成しない。
+  synthetics_canary_name = var.enable_synthetics_canary ? module.synthetics_canary[0].canary_name : ""
 }
 
 # --- Secrets Manager: ALB origin-verify header value (ADR-0030, Issue #465) ---

--- a/terraform/service/outputs.tf
+++ b/terraform/service/outputs.tf
@@ -78,3 +78,8 @@ output "synthetics_canary_artifacts_bucket_name" {
   description = "S3 bucket name storing Synthetics canary run artifacts. null when disabled"
   value       = var.enable_synthetics_canary ? module.synthetics_canary[0].canary_artifacts_bucket_name : null
 }
+
+output "synthetics_availability_alarm_name" {
+  description = "Name of the Synthetics canary time-based availability alarm (ADR-0030, Issue #467). null when disabled"
+  value       = module.monitoring.synthetics_availability_alarm_name
+}


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
ADR-0030で定義したtime-based availability SLI（Synthetics canaryのSuccessPercentを1時間平均で見る）を実装し、既存のburn-rateアラーム基盤（ADR-0026と同じSNS topic）に接続する。

## 変更内容（推奨）
- `terraform/modules/monitoring`: `nestjs-hannibal-3-synthetics-availability-low` アラームを追加（`synthetics_canary_name`が空文字の場合は作成しない）
- `terraform/service/main.tf`: canary名をmonitoringモジュールに渡す
- `docs/operations/runbook.md` / `docs/operations/monitoring.md`: 新規アラームの記載を追加

## 影響範囲（推奨）
- **対象**: `terraform/modules/monitoring`, `terraform/service`, `docs/operations/`
- **非対象**: `terraform/foundation`、既存のALB系burn-rateアラーム（変更なし）

## PRラベル（必須）
- **type**: type:infra
- **area**: area:infra
- **risk**: risk:low
- **cost**: cost:none

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**: `terraform/**`の変更のため厳密運用扱いだが、既存アラームへの変更はなく新規アラーム追加のみ。`count`によるconditional作成でcanary無効時に影響しない設計。

</details>

## 可観測性/検証 *条件付き*
dev環境デプロイ後、意図的にcanaryを失敗させる（例: origin-verifyヘッダー値を一時的に不正化する、またはALBを一時停止する）ことでアラームが実際にALARM状態に遷移することを実地検証する。検証結果は本PRのコメントで報告する。

## ロールバック *条件付き*
本PRの変更を`git revert`し、`terraform apply`することでアラームリソースを削除できる。既存のアラーム・SNS topicへの変更はないため既存監視への影響はない。

<details>
<summary>テスト結果/検証手順</summary>

- `terraform fmt -check -recursive`: 差分なし
- `terraform validate`: 全root module成功
- `tflint`: `terraform/service` / `terraform/modules/monitoring` ともに警告なし
- dev環境への実デプロイ・異常系実地検証は本PRマージ後に実施

</details>

## メモ（レビューポイント）
- `treat_missing_data = "breaching"` とした理由: canaryが1時間結果を報告しないこと自体がcanary(Lambda実行)の異常を示唆するため、ECS系アラームと同じ非対称設計（ADR-0026参照）を踏襲した
- 実際の可用性計上の正本は引き続き`ecs-task-stopped`/`slo-error-rate-slow-burn`であり、本アラームはユーザー視点の外形監視という別の側面を補完する位置づけ（slo.md参照）

Closes #467


Closes #467
