### PR TITLE
fix(infra): Synthetics canaryのaws-sdk依存を解消する

### DIFF
--- a/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
+++ b/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
@@ -10,15 +10,166 @@
 
 const synthetics = require('@aws/synthetics-puppeteer');
 const log = require('@aws/synthetics-logger');
-const AWS = require('aws-sdk');
+const crypto = require('crypto');
+const https = require('https');
 
-const secretsManager = new AWS.SecretsManager();
+const hashSha256 = (value) =>
+  crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+
+const hmacSha256 = (key, value, encoding) =>
+  crypto.createHmac('sha256', key).update(value, 'utf8').digest(encoding);
+
+const getSigningKey = (secretAccessKey, dateStamp, region, service) => {
+  const dateKey = hmacSha256(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = hmacSha256(dateKey, region);
+  const serviceKey = hmacSha256(regionKey, service);
+  return hmacSha256(serviceKey, 'aws4_request');
+};
+
+const getRequiredEnv = (name) => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+};
+
+const parseRegionFromSecretArn = (secretArn) => {
+  const arnParts = secretArn.split(':');
+  if (arnParts.length < 4 || arnParts[0] !== 'arn') {
+    throw new Error('ORIGIN_VERIFY_SECRET_ARN must be a valid ARN');
+  }
+  return arnParts[3];
+};
+
+const postJson = (hostname, headers, body) => {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname,
+        method: 'POST',
+        path: '/',
+        port: 443,
+        headers,
+      },
+      (res) => {
+        let responseBody = '';
+        res.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode < 200 || res.statusCode > 299) {
+            reject(
+              new Error(
+                `Secrets Manager GetSecretValue failed with status ${res.statusCode}`,
+              ),
+            );
+            return;
+          }
+
+          try {
+            resolve(JSON.parse(responseBody));
+          } catch (err) {
+            reject(
+              new Error(
+                `Secrets Manager GetSecretValue returned invalid JSON: ${err.message}`,
+              ),
+            );
+          }
+        });
+        res.on('error', reject);
+      },
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+};
+
+// Keep the canary zip dependency-free because Synthetics runtimes do not
+// guarantee the legacy aws-sdk v2 module.
+const getSecretValue = async (secretArn) => {
+  const service = 'secretsmanager';
+  const region =
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION ||
+    parseRegionFromSecretArn(secretArn);
+  const hostname = `${service}.${region}.amazonaws.com`;
+  const target = 'secretsmanager.GetSecretValue';
+  const contentType = 'application/x-amz-json-1.1';
+  const body = JSON.stringify({ SecretId: secretArn });
+
+  const accessKeyId = getRequiredEnv('AWS_ACCESS_KEY_ID');
+  const secretAccessKey = getRequiredEnv('AWS_SECRET_ACCESS_KEY');
+  const sessionToken = process.env.AWS_SESSION_TOKEN;
+  const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
+  const dateStamp = amzDate.slice(0, 8);
+
+  const signedHeaderNames = [
+    'content-type',
+    'host',
+    'x-amz-date',
+    ...(sessionToken ? ['x-amz-security-token'] : []),
+    'x-amz-target',
+  ];
+  const canonicalHeaders = [
+    `content-type:${contentType}`,
+    `host:${hostname}`,
+    `x-amz-date:${amzDate}`,
+    ...(sessionToken ? [`x-amz-security-token:${sessionToken}`] : []),
+    `x-amz-target:${target}`,
+  ].join('\n');
+  const payloadHash = hashSha256(body);
+  const canonicalRequest = [
+    'POST',
+    '/',
+    '',
+    `${canonicalHeaders}\n`,
+    signedHeaderNames.join(';'),
+    payloadHash,
+  ].join('\n');
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    hashSha256(canonicalRequest),
+  ].join('\n');
+  const signingKey = getSigningKey(
+    secretAccessKey,
+    dateStamp,
+    region,
+    service,
+  );
+  const signature = hmacSha256(signingKey, stringToSign, 'hex');
+
+  const headers = {
+    'Content-Type': contentType,
+    Host: hostname,
+    'X-Amz-Date': amzDate,
+    'X-Amz-Target': target,
+    Authorization: `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaderNames.join(';')}, Signature=${signature}`,
+  };
+
+  if (sessionToken) {
+    headers['X-Amz-Security-Token'] = sessionToken;
+  }
+
+  const result = await postJson(hostname, headers, body);
+  if (typeof result.SecretString === 'string') {
+    return result.SecretString;
+  }
+  if (typeof result.SecretBinary === 'string') {
+    return Buffer.from(result.SecretBinary, 'base64').toString('utf8');
+  }
+  throw new Error(
+    'Secrets Manager GetSecretValue response did not include a secret value',
+  );
+};
 
 const getOriginVerifyHeaderValue = async (secretArn) => {
-  const result = await secretsManager
-    .getSecretValue({ SecretId: secretArn })
-    .promise();
-  return result.SecretString;
+  return await getSecretValue(secretArn);
 };
 
 const buildJsonPostOptions = (urlString, body, extraHeaders) => {


### PR DESCRIPTION
## 目的（推奨）
Synthetics canary が runtime 内に存在しない `aws-sdk` を参照して `Cannot find module 'aws-sdk'` で失敗する状態を解消する。

## 変更内容（推奨）
- canary script の Secrets Manager `GetSecretValue` 呼び出しを、Node.js 標準ライブラリ (`https` / `crypto`) による SigV4 署名リクエストへ置き換えた。
- secret 値はログへ出さず、既存の origin-verify header 注入フローは維持した。

## 影響範囲（推奨）
- **対象**: `terraform/modules/synthetics` の canary runtime script
- **非対象**: IAM policy、network/database/service/cdn module 構成、アプリ本体

## PRラベル（必須）
- **type**: `type:bug`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
- `node --check terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js`
- secret 値を表示せず、SigV4 `GetSecretValue` の実呼び出しが `secretLength: 32` を返すことを確認
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform/{foundation,network,database,service,cdn,observability} init -backend=false -input=false && terraform validate`
- `pre-commit run --files terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js`
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*
軽運用PR。問題があれば本PRを revert し、canary script を直前の実装へ戻す。環境リソースのロールバックは不要。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- `deploy.yml` run `28847803162` は workflow と CodeDeploy は成功したが、canary run が `Cannot find module 'aws-sdk'` で失敗していた。
- 本PR merge後に `deploy.yml` を再実行し、`hannibal-canary` の run 成功を確認する。

</details>

## メモ（レビューポイント）
Synthetics runtime に SDK 同梱を仮定せず、canary zip に npm install 手順も増やさないため、標準ライブラリだけで Secrets Manager の SigV4 呼び出しを行う。


Closes #473
