### PR TITLE
fix(infra): Synthetics canaryのコード更新を検知する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .terraform/
+.artifacts/
+**/.artifacts/
 *.tfvars
 *.tfvars.json
 

--- a/terraform/modules/synthetics/main.tf
+++ b/terraform/modules/synthetics/main.tf
@@ -3,6 +3,10 @@
 
 data "aws_caller_identity" "current" {}
 
+locals {
+  canary_code_s3_key = "canary-code/${data.archive_file.canary_zip.output_sha256}.zip"
+}
+
 # --- S3 bucket for canary artifacts (screenshots, HAR files, logs) ---
 resource "aws_s3_bucket" "canary_artifacts" {
   bucket        = "${var.project_name}-synthetics-canary-artifacts"
@@ -128,13 +132,28 @@ data "archive_file" "canary_zip" {
   output_path = "${path.module}/.artifacts/apiCanary.zip"
 }
 
+resource "aws_s3_object" "canary_code" {
+  bucket      = aws_s3_bucket.canary_artifacts.id
+  key         = local.canary_code_s3_key
+  source      = data.archive_file.canary_zip.output_path
+  source_hash = data.archive_file.canary_zip.output_base64sha256
+
+  tags = merge(
+    {
+      Name = "${var.canary_name}-code"
+    },
+    var.tags,
+  )
+}
+
 # --- Synthetics canary ---
 resource "aws_synthetics_canary" "user_journey" {
   name                 = var.canary_name
   artifact_s3_location = "s3://${aws_s3_bucket.canary_artifacts.bucket}/canary-runs/"
   execution_role_arn   = aws_iam_role.canary_execution.arn
   handler              = "apiCanary.handler"
-  zip_file             = data.archive_file.canary_zip.output_path
+  s3_bucket            = aws_s3_bucket.canary_artifacts.bucket
+  s3_key               = aws_s3_object.canary_code.key
   runtime_version      = var.runtime_version
 
   schedule {
@@ -163,6 +182,7 @@ resource "aws_synthetics_canary" "user_journey" {
   )
 
   depends_on = [
-    aws_iam_role_policy.canary_execution
+    aws_iam_role_policy.canary_execution,
+    aws_s3_object.canary_code
   ]
 }


### PR DESCRIPTION
## 目的（推奨）
`aws_synthetics_canary.zip_file` が zip の中身変更を差分検知せず、#473 の canary script 修正が実行環境へ反映されない問題を解消する。

## 変更内容（推奨）
- canary zip を `aws_s3_object.canary_code` として artifact bucket にアップロードする。
- `data.archive_file.canary_zip.output_sha256` を含む S3 key を使い、コード内容が変わると `s3_key` も変わるようにした。
- `aws_synthetics_canary` は `zip_file` ではなく `s3_bucket` / `s3_key` を参照する。
- Terraform が生成する `.artifacts/` を `.gitignore` に追加した。

## 影響範囲（推奨）
- **対象**: `terraform/modules/synthetics` の canary code package 更新方式
- **非対象**: IAM policy、ECS/CodeDeploy、database/network/cdn の設計

## PRラベル（必須）
- **type**: `type:bug`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform/service validate`
- `tflint --chdir=terraform/service`
- `pre-commit run --files .gitignore terraform/modules/synthetics/main.tf terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js`
- `terraform -chdir=terraform/service plan ...` で `aws_s3_object.canary_code` create と `aws_synthetics_canary.user_journey` update のみ確認（`1 to add, 1 to change, 0 to destroy`）
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*
軽運用PR。問題があれば本PRを revert し、`aws_synthetics_canary` の code source を `zip_file` へ戻す。環境破棄は通常の `destroy.yml` で可能。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- 再deploy run `28849141782` は成功したが、`hannibal-canary` の `LastModified` が `16:02 JST` のままで code 更新が反映されていないことを確認。
- AWS provider 6.8.0 の schema では `aws_synthetics_canary` に `source_code_hash` がないことを確認。
- 正しい ALB certificate ARN を渡した plan で Synthetics 関連のみの差分に収束することを確認。

</details>

## メモ（レビューポイント）
hash入り S3 key を canary の入力にすることで、zip 内容変更を Terraform の resource diff として扱う。


Closes #475
