### PR TITLE
fix(infra): Synthetics canaryをCloudFront経由にする

### DIFF
--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -84,6 +84,26 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   ordered_cache_behavior {
+    path_pattern           = "/health"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = "ALB-${var.project_name}-API"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+      headers = ["User-Agent"]
+    }
+  }
+
+  ordered_cache_behavior {
     path_pattern           = "/api/*"
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD", "OPTIONS"]

--- a/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
+++ b/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
@@ -2,10 +2,11 @@
 //
 // 検証対象は次の3ステップに限定する(認証機能は本アプリに存在しないため対象外、書き込み系APIも対象外):
 //   1. frontend-delivery : CloudFront経由のフロントエンド配信確認
-//   2. alb-health-check  : ALB直接のヘルスチェック(GET /)。X-Hannibal-Origin-Verify ヘッダーが必要
-//   3. graphql-read-query: ALB直接のGraphQL読み取りクエリ。同ヘッダーが必要
+//   2. alb-health-check  : CloudFront経由のALBヘルスチェック(GET /health)
+//   3. graphql-read-query: CloudFront経由のGraphQL読み取りクエリ
 //
 // origin-verifyヘッダーの値はコードに埋め込まず、実行時にSecrets Managerから取得する。
+// CloudFrontがoriginへ同ヘッダーを付与するが、canary側でもsecretの取得可否を検査対象に含める。
 // 実行roleにはこのsecret ARNに限定したGetSecretValueのみを付与する(最小権限)。
 
 const synthetics = require('@aws/synthetics-puppeteer');
@@ -275,14 +276,14 @@ const userJourneyCanary = async function () {
     consumeAndCheckStatus('frontend-delivery'),
   );
 
-  // Step 2: health check via ALB directly (requires origin-verify header)
+  // Step 2: health check via CloudFront to the ALB origin
   await synthetics.executeHttpStep(
     'alb-health-check',
     buildGetOptions(apiHealthUrl, originVerifyHeaders),
     consumeAndCheckStatus('alb-health-check'),
   );
 
-  // Step 3: GraphQL read-only query via ALB directly (requires origin-verify header)
+  // Step 3: GraphQL read-only query via CloudFront to the ALB origin
   await synthetics.executeHttpStep(
     'graphql-read-query',
     buildJsonPostOptions(

--- a/terraform/modules/synthetics/variables.tf
+++ b/terraform/modules/synthetics/variables.tf
@@ -43,12 +43,12 @@ variable "frontend_url" {
 }
 
 variable "api_health_url" {
-  description = "Backend health check URL, requested directly against the ALB (user journey step 2)"
+  description = "Backend health check URL requested via CloudFront (user journey step 2)"
   type        = string
 }
 
 variable "api_graphql_url" {
-  description = "Backend GraphQL endpoint URL, requested directly against the ALB (user journey step 3: read-only query)"
+  description = "Backend GraphQL endpoint URL requested via CloudFront (user journey step 3: read-only query)"
   type        = string
 }
 

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -111,8 +111,8 @@ module "synthetics_canary" {
   schedule_expression = var.synthetics_schedule_expression
 
   frontend_url    = "https://${var.domain_name}/"
-  api_health_url  = "https://api.${var.domain_name}${var.health_check_path}"
-  api_graphql_url = "https://api.${var.domain_name}/graphql"
+  api_health_url  = "https://${var.domain_name}${var.health_check_path}"
+  api_graphql_url = "https://${var.domain_name}/graphql"
   graphql_query   = var.synthetics_graphql_query
 
   origin_verify_header_name = local.alb_origin_verify_header_name


### PR DESCRIPTION
## 目的（推奨）
Synthetics canary が ALB 直の `api.hamilcar-hannibal.click` へ接続して timeout する問題を解消する。ALB security group は CloudFront origin-facing prefix list のみ許可しているため、canary も CloudFront 経由のユーザージャーニー監視に合わせる。

## 変更内容（推奨）
- `terraform/service` の canary health/graphql URL を `https://hamilcar-hannibal.click` 配下へ変更。
- CloudFront に `/health` を ALB origin へ転送する ordered cache behavior を追加。
- Synthetics module の変数説明と canary script コメントを CloudFront 経由に更新。

## 影響範囲（推奨）
- **対象**: Synthetics canary の API到達経路、CloudFront `/health` behavior
- **非対象**: ALB security group、ECS/DB、CodeDeploy方式、CloudFront `/graphql` 既存behavior

## PRラベル（必須）
- **type**: `type:bug`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform/service validate`
- `terraform -chdir=terraform/cdn validate`
- `tflint --chdir=terraform/service` / `tflint --chdir=terraform/cdn`
- `node --check terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js`
- `pre-commit run --files terraform/service/main.tf terraform/modules/cloudfront/main.tf terraform/modules/synthetics/variables.tf terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js`
- service plan: canary code object replace + canary update (`1 to add, 1 to change, 1 to destroy`)
- cdn plan: CloudFront distribution in-place update (`0 to add, 1 to change, 0 to destroy`)
- `npm run commitlint -- --from main --to HEAD --verbose`

## ロールバック *条件付き*
軽運用PR。問題があれば本PRを revert し、canary URL と CloudFront `/health` behavior を戻す。通常の `destroy.yml` による環境破棄も可能。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- `hannibal-canary` は #476 後に code update され、Secrets Manager 取得と frontend step は通過。
- 失敗点は `alb-health-check` の TCP timeout（`api.hamilcar-hannibal.click:443`）。ALB SG が CloudFront origin-facing prefix list のみ許可しているため設計不整合と判断。
- 本PR merge後に `deploy.yml` を再実行し、`hannibal-canary` run が `PASSED` になることを確認する。

</details>

## メモ（レビューポイント）
CloudFront は既に `/graphql` を ALB origin へ転送しているため、追加するのは `/health` behavior のみ。


Closes #477
