### PR TITLE
fix(infra): Synthetics canaryのorigin-verifyヘッダー機構をdead codeとして削除する

### DIFF
--- a/docs/adr/0030-adopt-cloudwatch-synthetics-canary-for-user-journey-monitoring.md
+++ b/docs/adr/0030-adopt-cloudwatch-synthetics-canary-for-user-journey-monitoring.md
@@ -71,6 +71,15 @@ canary を env 側に配置し on-demand deploy/destroy と生死を共にする
 - 後続 Issue で canary の成功/失敗結果を CloudWatch Alarm 経由で `terraform/modules/monitoring` の SNS topic に接続する
 - コスト影響: canary 実行中のみ課金が発生する（Synthetics canary 実行料、S3 artifact 保存料）。env 起動期間中は `cost:small` 相当と見込む。本 ADR 自体（ドキュメントのみ）は `cost:none`
 
+## 更新（2026-07-07、Issue #481）
+
+PR [#478](https://github.com/kmryst/terraform-hannibal/pull/478) で canary の通信経路を ALB 直接から CloudFront 経由に変更した結果、canary 自身が Secrets Manager から secret を取得して `X-Hannibal-Origin-Verify` ヘッダーを付与する機構は dead code となったため削除した。
+
+- CloudFront の forwarded-headers whitelist（`terraform/modules/cloudfront/main.tf`）はこのヘッダーを origin へ転送しないため、canary が付与しても ALB には届かず、機能上の意味がなかった
+- ALB 直接アクセス防止の実効的な統制は CloudFront 自身の `custom_header`（origin 設定に静的に埋め込まれ、サーバー側で注入されるためクライアントから偽装不可）であり、canary の関与を必要としない
+- このヘッダーを CloudFront の forwarded-headers に追加して canary 側機構を「復活」させる案は採らなかった。クライアントが制御可能な転送ヘッダーに変わりセキュリティ後退となるうえ、burn-rate アラームに接続された可用性 SLI に「Secrets Manager 取得失敗」というユーザージャーニーと無関係な失敗モードを残すことになるため
+- 削除対象: canary スクリプトの secret 取得・ヘッダー付与ロジック、canary 実行 role の `secretsmanager:GetSecretValue`、`terraform/modules/synthetics` の origin-verify 系変数、canary 専用だった `terraform/service` の Secrets Manager secret リソース。CloudFront / load-balancer 側の origin-verify 機構そのものは変更していない
+
 ## 関連
 
 - [docs/operations/slo.md](../operations/slo.md)

--- a/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
+++ b/terraform/modules/synthetics/canary-src/nodejs/node_modules/apiCanary.js
@@ -2,178 +2,16 @@
 //
 // 検証対象は次の3ステップに限定する(認証機能は本アプリに存在しないため対象外、書き込み系APIも対象外):
 //   1. frontend-delivery : CloudFront経由のフロントエンド配信確認
-//   2. alb-health-check  : CloudFront経由のALBヘルスチェック(GET /health)
+//   2. api-health-check  : CloudFront経由のAPIヘルスチェック(GET /health)
 //   3. graphql-read-query: CloudFront経由のGraphQL読み取りクエリ
 //
-// origin-verifyヘッダーの値はコードに埋め込まず、実行時にSecrets Managerから取得する。
-// CloudFrontがoriginへ同ヘッダーを付与するが、canary側でもsecretの取得可否を検査対象に含める。
-// 実行roleにはこのsecret ARNに限定したGetSecretValueのみを付与する(最小権限)。
+// 全ステップはCloudFront経由でアクセスする(PR #478)。ALB直接アクセス防止(origin-verifyヘッダー)は
+// CloudFront自身のcustom_header(terraform/modules/cloudfront)がサーバー側で付与する統制であり、
+// canaryはヘッダーの取得・付与に関与しない(ADR-0030「更新」節参照)。
 
 const synthetics = require('@aws/synthetics-puppeteer');
-const log = require('@aws/synthetics-logger');
-const crypto = require('crypto');
-const https = require('https');
 
-const hashSha256 = (value) =>
-  crypto.createHash('sha256').update(value, 'utf8').digest('hex');
-
-const hmacSha256 = (key, value, encoding) =>
-  crypto.createHmac('sha256', key).update(value, 'utf8').digest(encoding);
-
-const getSigningKey = (secretAccessKey, dateStamp, region, service) => {
-  const dateKey = hmacSha256(`AWS4${secretAccessKey}`, dateStamp);
-  const regionKey = hmacSha256(dateKey, region);
-  const serviceKey = hmacSha256(regionKey, service);
-  return hmacSha256(serviceKey, 'aws4_request');
-};
-
-const getRequiredEnv = (name) => {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-};
-
-const parseRegionFromSecretArn = (secretArn) => {
-  const arnParts = secretArn.split(':');
-  if (arnParts.length < 4 || arnParts[0] !== 'arn') {
-    throw new Error('ORIGIN_VERIFY_SECRET_ARN must be a valid ARN');
-  }
-  return arnParts[3];
-};
-
-const postJson = (hostname, headers, body) => {
-  return new Promise((resolve, reject) => {
-    const req = https.request(
-      {
-        hostname,
-        method: 'POST',
-        path: '/',
-        port: 443,
-        headers,
-      },
-      (res) => {
-        let responseBody = '';
-        res.on('data', (chunk) => {
-          responseBody += chunk;
-        });
-        res.on('end', () => {
-          if (res.statusCode < 200 || res.statusCode > 299) {
-            reject(
-              new Error(
-                `Secrets Manager GetSecretValue failed with status ${res.statusCode}`,
-              ),
-            );
-            return;
-          }
-
-          try {
-            resolve(JSON.parse(responseBody));
-          } catch (err) {
-            reject(
-              new Error(
-                `Secrets Manager GetSecretValue returned invalid JSON: ${err.message}`,
-              ),
-            );
-          }
-        });
-        res.on('error', reject);
-      },
-    );
-
-    req.on('error', reject);
-    req.write(body);
-    req.end();
-  });
-};
-
-// Keep the canary zip dependency-free because Synthetics runtimes do not
-// guarantee the legacy aws-sdk v2 module.
-const getSecretValue = async (secretArn) => {
-  const service = 'secretsmanager';
-  const region =
-    process.env.AWS_REGION ||
-    process.env.AWS_DEFAULT_REGION ||
-    parseRegionFromSecretArn(secretArn);
-  const hostname = `${service}.${region}.amazonaws.com`;
-  const target = 'secretsmanager.GetSecretValue';
-  const contentType = 'application/x-amz-json-1.1';
-  const body = JSON.stringify({ SecretId: secretArn });
-
-  const accessKeyId = getRequiredEnv('AWS_ACCESS_KEY_ID');
-  const secretAccessKey = getRequiredEnv('AWS_SECRET_ACCESS_KEY');
-  const sessionToken = process.env.AWS_SESSION_TOKEN;
-  const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
-  const dateStamp = amzDate.slice(0, 8);
-
-  const signedHeaderNames = [
-    'content-type',
-    'host',
-    'x-amz-date',
-    ...(sessionToken ? ['x-amz-security-token'] : []),
-    'x-amz-target',
-  ];
-  const canonicalHeaders = [
-    `content-type:${contentType}`,
-    `host:${hostname}`,
-    `x-amz-date:${amzDate}`,
-    ...(sessionToken ? [`x-amz-security-token:${sessionToken}`] : []),
-    `x-amz-target:${target}`,
-  ].join('\n');
-  const payloadHash = hashSha256(body);
-  const canonicalRequest = [
-    'POST',
-    '/',
-    '',
-    `${canonicalHeaders}\n`,
-    signedHeaderNames.join(';'),
-    payloadHash,
-  ].join('\n');
-  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
-  const stringToSign = [
-    'AWS4-HMAC-SHA256',
-    amzDate,
-    credentialScope,
-    hashSha256(canonicalRequest),
-  ].join('\n');
-  const signingKey = getSigningKey(
-    secretAccessKey,
-    dateStamp,
-    region,
-    service,
-  );
-  const signature = hmacSha256(signingKey, stringToSign, 'hex');
-
-  const headers = {
-    'Content-Type': contentType,
-    Host: hostname,
-    'X-Amz-Date': amzDate,
-    'X-Amz-Target': target,
-    Authorization: `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaderNames.join(';')}, Signature=${signature}`,
-  };
-
-  if (sessionToken) {
-    headers['X-Amz-Security-Token'] = sessionToken;
-  }
-
-  const result = await postJson(hostname, headers, body);
-  if (typeof result.SecretString === 'string') {
-    return result.SecretString;
-  }
-  if (typeof result.SecretBinary === 'string') {
-    return Buffer.from(result.SecretBinary, 'base64').toString('utf8');
-  }
-  throw new Error(
-    'Secrets Manager GetSecretValue response did not include a secret value',
-  );
-};
-
-const getOriginVerifyHeaderValue = async (secretArn) => {
-  return await getSecretValue(secretArn);
-};
-
-const buildJsonPostOptions = (urlString, body, extraHeaders) => {
+const buildJsonPostOptions = (urlString, body) => {
   const url = new URL(urlString);
   return {
     hostname: url.hostname,
@@ -181,25 +19,10 @@ const buildJsonPostOptions = (urlString, body, extraHeaders) => {
     path: `${url.pathname}${url.search || ''}`,
     port: url.protocol === 'https:' ? 443 : 80,
     protocol: url.protocol,
-    headers: Object.assign(
-      {
-        'Content-Type': 'application/json',
-      },
-      extraHeaders,
-    ),
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(body),
-  };
-};
-
-const buildGetOptions = (urlString, extraHeaders) => {
-  const url = new URL(urlString);
-  return {
-    hostname: url.hostname,
-    method: 'GET',
-    path: `${url.pathname}${url.search || ''}`,
-    port: url.protocol === 'https:' ? 443 : 80,
-    protocol: url.protocol,
-    headers: extraHeaders || {},
   };
 };
 
@@ -257,17 +80,7 @@ const userJourneyCanary = async function () {
   const frontendUrl = process.env.FRONTEND_URL;
   const apiHealthUrl = process.env.API_HEALTH_URL;
   const apiGraphqlUrl = process.env.API_GRAPHQL_URL;
-  const originVerifyHeaderName = process.env.ORIGIN_VERIFY_HEADER_NAME;
-  const originVerifySecretArn = process.env.ORIGIN_VERIFY_SECRET_ARN;
   const graphqlQuery = process.env.GRAPHQL_QUERY;
-
-  log.info('Fetching ALB origin-verify header value from Secrets Manager');
-  const originVerifyHeaderValue = await getOriginVerifyHeaderValue(
-    originVerifySecretArn,
-  );
-  const originVerifyHeaders = {
-    [originVerifyHeaderName]: originVerifyHeaderValue,
-  };
 
   // Step 1: frontend delivery via CloudFront
   await synthetics.executeHttpStep(
@@ -276,21 +89,17 @@ const userJourneyCanary = async function () {
     consumeAndCheckStatus('frontend-delivery'),
   );
 
-  // Step 2: health check via CloudFront to the ALB origin
+  // Step 2: API health check via CloudFront
   await synthetics.executeHttpStep(
-    'alb-health-check',
-    buildGetOptions(apiHealthUrl, originVerifyHeaders),
-    consumeAndCheckStatus('alb-health-check'),
+    'api-health-check',
+    apiHealthUrl,
+    consumeAndCheckStatus('api-health-check'),
   );
 
-  // Step 3: GraphQL read-only query via CloudFront to the ALB origin
+  // Step 3: GraphQL read-only query via CloudFront
   await synthetics.executeHttpStep(
     'graphql-read-query',
-    buildJsonPostOptions(
-      apiGraphqlUrl,
-      { query: graphqlQuery },
-      originVerifyHeaders,
-    ),
+    buildJsonPostOptions(apiGraphqlUrl, { query: graphqlQuery }),
     jsonCallback('graphql-read-query'),
   );
 };

--- a/terraform/modules/synthetics/main.tf
+++ b/terraform/modules/synthetics/main.tf
@@ -60,8 +60,8 @@ resource "aws_iam_role" "canary_execution" {
 }
 
 # 参照: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_CanaryPermissions.html
-# 「Basic canary that doesn't use AWS KMS or need Amazon VPC access」の権限セットを基本とし、
-# GetSecretValueをorigin-verifyヘッダー用secretのARNのみに限定して追加する(最小権限、Issue #465)。
+# 「Basic canary that doesn't use AWS KMS or need Amazon VPC access」の権限セットのみを付与する(最小権限)。
+# canaryはCloudFront経由でアクセスするため、Secrets Manager等の追加権限は不要(Issue #481)。
 resource "aws_iam_role_policy" "canary_execution" {
   name = "${var.project_name}-synthetics-canary-policy"
   role = aws_iam_role.canary_execution.id
@@ -112,14 +112,6 @@ resource "aws_iam_role_policy" "canary_execution" {
             "cloudwatch:namespace" = "CloudWatchSynthetics"
           }
         }
-      },
-      {
-        # 最小権限: origin-verifyヘッダー用secretのARNのみに限定する(ワイルドカードで全secretを許可しない)
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = [var.origin_verify_secret_arn]
       }
     ]
   })
@@ -163,12 +155,10 @@ resource "aws_synthetics_canary" "user_journey" {
   run_config {
     timeout_in_seconds = var.canary_timeout_in_seconds
     environment_variables = {
-      FRONTEND_URL              = var.frontend_url
-      API_HEALTH_URL            = var.api_health_url
-      API_GRAPHQL_URL           = var.api_graphql_url
-      ORIGIN_VERIFY_HEADER_NAME = var.origin_verify_header_name
-      ORIGIN_VERIFY_SECRET_ARN  = var.origin_verify_secret_arn
-      GRAPHQL_QUERY             = var.graphql_query
+      FRONTEND_URL    = var.frontend_url
+      API_HEALTH_URL  = var.api_health_url
+      API_GRAPHQL_URL = var.api_graphql_url
+      GRAPHQL_QUERY   = var.graphql_query
     }
   }
 

--- a/terraform/modules/synthetics/variables.tf
+++ b/terraform/modules/synthetics/variables.tf
@@ -58,16 +58,6 @@ variable "graphql_query" {
   default     = "query { capitalCities { type features { type properties { name } } } }"
 }
 
-variable "origin_verify_header_name" {
-  description = "Name of the ALB origin-verify header required to bypass the 403 deny rule (see terraform/modules/load-balancer)"
-  type        = string
-}
-
-variable "origin_verify_secret_arn" {
-  description = "Secrets Manager secret ARN that stores the ALB origin-verify header value. The canary execution role is granted GetSecretValue scoped to this ARN only"
-  type        = string
-}
-
 variable "tags" {
   description = "Additional tags for canary-related resources"
   type        = map(string)

--- a/terraform/service/README.md
+++ b/terraform/service/README.md
@@ -15,7 +15,6 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
@@ -33,8 +32,6 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 
 | Name | Type |
 |------|------|
-| [aws_secretsmanager_secret.alb_origin_verify_header](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.alb_origin_verify_header](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [random_password.alb_origin_verify_header](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [terraform_remote_state.database](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.network](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -83,24 +83,9 @@ module "monitoring" {
   synthetics_canary_name = var.enable_synthetics_canary ? module.synthetics_canary[0].canary_name : ""
 }
 
-# --- Secrets Manager: ALB origin-verify header value (ADR-0030, Issue #465) ---
-# random_password.alb_origin_verify_header の値をSecrets Managerにも登録し、
-# Synthetics canary実行roleに対してこのARNに限定したGetSecretValueのみを付与する(平文をTerraform変数やコードに残さない)。
-resource "aws_secretsmanager_secret" "alb_origin_verify_header" {
-  name                    = "${var.project_name}-alb-origin-verify-header"
-  description             = "ALB origin-verify header value used by CloudFront and the Synthetics canary to pass the ALB deny-without-header rule"
-  recovery_window_in_days = 0 # dev環境のon-demand destroy運用(ADR-0008)に合わせて即時削除可能にする
-
-  tags = {
-    Name = "${var.project_name}-alb-origin-verify-header"
-  }
-}
-
-resource "aws_secretsmanager_secret_version" "alb_origin_verify_header" {
-  secret_id     = aws_secretsmanager_secret.alb_origin_verify_header.id
-  secret_string = random_password.alb_origin_verify_header.result
-}
-
+# Synthetics canaryはCloudFront経由でアクセスするため、origin-verifyヘッダー用の
+# Secrets Manager secretとcanaryへの受け渡しは不要(Issue #481、ADR-0030「更新」節参照)。
+# ALB直接アクセス防止はCloudFront custom_header + load-balancerのdenyルールで完結する。
 module "synthetics_canary" {
   count  = var.enable_synthetics_canary ? 1 : 0
   source = "../modules/synthetics"
@@ -114,9 +99,6 @@ module "synthetics_canary" {
   api_health_url  = "https://${var.domain_name}${var.health_check_path}"
   api_graphql_url = "https://${var.domain_name}/graphql"
   graphql_query   = var.synthetics_graphql_query
-
-  origin_verify_header_name = local.alb_origin_verify_header_name
-  origin_verify_secret_arn  = aws_secretsmanager_secret.alb_origin_verify_header.arn
 
   tags = {
     Environment = var.environment


### PR DESCRIPTION
## 目的

PR #478 でcanaryの通信経路をCloudFront経由に変更した結果、canary自身がSecrets Managerからsecretを取得して `X-Hannibal-Origin-Verify` ヘッダーを付与する機構はdead codeになった（CloudFrontのforwarded-headers whitelistが同ヘッダーをoriginへ転送しないため、付与してもALBに届かない）。dead code一式を削除し、canary実行roleの最小権限を回復する。また、可用性SLI（burn-rateアラーム接続済み）から「Secrets Manager取得失敗」というユーザージャーニーと無関係な失敗モードを排除する。

## 変更内容

- `apiCanary.js`: Secrets Manager取得（自前SigV4署名実装含む）とヘッダー付与ロジックを削除。step名 `alb-health-check` を `api-health-check` に改名（経路はCloudFront経由のため）
- `terraform/modules/synthetics/main.tf`: 実行roleのSecrets Manager読み取り statement と `ORIGIN_VERIFY_*` 環境変数を削除
- `terraform/modules/synthetics/variables.tf`: `origin_verify_header_name` / `origin_verify_secret_arn` を削除
- `terraform/service/main.tf`: canary専用だった `aws_secretsmanager_secret(_version).alb_origin_verify_header` とmodule引数を削除
- `docs/adr/0030`: 削除の経緯と「forwarded-headersに追加して復活させない」判断を「更新」節として追記
- `terraform/service/README.md`: terraform-docsで再生成

## 影響範囲

- **対象**: Synthetics canary（スクリプト・IAM・変数）、`terraform/service` のcanary用secretリソース
- **非対象**: CloudFrontの `custom_header` 機構、load-balancerのdenyルール、`random_password` とservice output（CloudFront/ALB間の統制はそのまま）。アプリ本体・CI/CD

## PRラベル（必須）

`type:infra`, `area:infra`, `risk:low`, `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**: 削除のみ（権限縮小・dead code除去）。ALB直接アクセス防止はCloudFront custom_headerで独立に担保されており、canary側削除による統制の弱体化はない。

</details>

## 可観測性/検証

- `terraform fmt -check -recursive`: 差分なし
- `terraform -chdir=terraform/service init -backend=false && validate`: Success
- pre-commit（tflint / terraform_docs / secrets scan）: Passed
- 静的変更のみのためdev環境へのdeploy/destroyは実施しない（新規ランタイム挙動なし、削除のみ）。次回 `deploy.yml` 実行時にcanaryが3ステップ成功することを確認する

## ロールバック

本PRをrevertして `deploy.yml` を再実行すれば、canary用secret・IAM statement・canaryスクリプトの旧ロジックが完全に復元される。削除対象はいずれも `terraform/service` root module管理下（deploy/destroyで自動管理、ADR-0008）であり、state手術は不要。Secrets Manager secretは `recovery_window_in_days = 0` のため名前衝突による再作成失敗も起きない。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- CloudFront側（`terraform/modules/cloudfront/main.tf`）に一切触れていないこと
- `random_password.alb_origin_verify_header` / output `alb_origin_verify_header_value` はcdn root moduleが参照するため残していること


Closes #481
