### PR TITLE
ci: add queue: max to pr-policy-check concurrency

### DIFF
--- a/.github/workflows/pr-policy-check.yml
+++ b/.github/workflows/pr-policy-check.yml
@@ -13,6 +13,10 @@ concurrency:
   # 実行中 run のキャンセルは CANCELLED check run を commit に残し、
   # required status checks の判定に混入して PR を恒久的にブロックする（Issue #438）。
   cancel-in-progress: false
+  # デフォルト（queue: single）は pending run を1つしか保持せず、labeled/unlabeled 連発時に
+  # 古い pending run が cancel されて required check が一時的に expected 扱いになるため、
+  # pending run を cancel せず FIFO で順次実行する（Issue #485）。
+  queue: max
 
 jobs:
   pr-policy-check:


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
PR作成 helper のラベル連続付与で `pull_request.labeled` イベントが連発し、GitHub Actions のデフォルト（`queue: single`）で pr-policy-check.yml の pending run が cancel され、required status check が一時的に expected 扱いになる事象が idp-golden-path で発生した。同一構成の本リポジトリにも同じ問題が潜在する。

## 変更内容（推奨）
`.github/workflows/pr-policy-check.yml` の `concurrency` に `queue: max` を追加し、pending run を cancel せず FIFO で順次実行する。

## 影響範囲（推奨）
- **対象**: `.github/workflows/pr-policy-check.yml`
- **非対象**: `cancel-in-progress: true` を使う `pr-check.yml` 等（`queue: max` は追加しない）

## PRラベル（必須）
- **type**: `type:infra`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**: なし
**リスク根拠**: `queue: max` は `cancel-in-progress: false` と併用可能（`cancel-in-progress: true` との併用のみ validation error）。ラベル判定は `gh pr view` で最新ラベルを再取得しているため、古い payload の run が後から実行されても判定結果への影響はない。

</details>

## 可観測性/検証 *条件付き*
- 本 PR 自身の CI で `pr-policy-check.yml` が構文エラーなく起動・成功することを確認する
- 本 PR に短時間でラベルを複数回付け外しし、`gh run list` で pending run が `CANCELLED` にならず FIFO で順次実行されることを確認する

## ロールバック *条件付き*
`concurrency` ブロックの `queue: max` の行（コメント含む）を削除するだけで元の挙動に戻せる。設定ミスがあれば pr-policy-check.yml 自体が起動しない/失敗するため即座に気づける。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

後述のコメントで `gh run list` の結果を追記する。

</details>

## メモ（レビューポイント）
`.github/workflows/**` の変更のため厳密運用。`queue: max` と `cancel-in-progress: true` の併用は validation error になるため、他ワークフローへの横展開時は要注意。

Closes #485


Closes #485
