### PR TITLE
docs: record pr-policy-check queue:max fix in ops docs

### DIFF
--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -97,6 +97,13 @@ docker buildx imagetools inspect ghcr.io/hadolint/hadolint:v2.14.0
 - `pr-check.yml` は PR 番号単位の workflow concurrency で古い heavy CI run をキャンセルする
 - `pr-policy-check.yml` と `pr-commitlint.yml` も PR 番号単位の concurrency を持つが、workflow を分けることで label 変更時の `PR Policy Check` 更新が `Commitlint` を巻き込んでキャンセルしない
 
+`pr-policy-check.yml` の concurrency は `cancel-in-progress: false` かつ `queue: max` とします。
+
+- `cancel-in-progress: false`: 実行中 run を cancel すると CANCELLED check run が commit に残り、required status check の判定に混入して PR を恒久ブロックし得るため cancel しない（Issue #438）
+- `queue: max`: concurrency のデフォルト（`queue: single`）は pending run を 1 つしか保持しないため、PR 作成 helper のラベル連続付与で `pull_request.labeled` が連発すると古い pending run が cancel され、required check が一時的に `expected`（未充足）扱いになる。`queue: max` は pending run を cancel せず FIFO で順次実行させることでこれを防ぐ（Issue #485 / PR #486）
+- `queue: max` は `cancel-in-progress: false` とのみ併用でき、`cancel-in-progress: true` との併用は validation error になる。したがって heavy CI を新 SHA で上書きするために `cancel-in-progress: true` を使う `pr-check.yml` には `queue: max` を付けない
+- 検証: idp-golden-path / terraform-hannibal / ticket-c2c-platform の同一構成 3 リポジトリでラベルを 11 回連続付け外しし、3 リポジトリ合計 47 run で CANCELLED 0 件を確認した
+
 required status check の context 名は既存の branch protection と互換にするため、次を維持します。
 
 `PR Policy Check` / `Commitlint` / `Backend Lint & Build` / `Frontend Build` / `Terraform Format & Validate` / `TFLint` / `Gitleaks Secret Scan`

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -64,3 +64,17 @@
 **成果**: 安全な並行実行制御と、チーム開発に対応可能な基盤を構築
 
 **学び**: IaCにおける状態管理の重要性と、チーム開発を見据えた設計
+
+## 6. PR Policy Check の pending run が cancel され required check がブロックされる問題
+
+**課題**: PR 作成 helper がラベル（type/area/risk/cost）を連続付与すると `pull_request` の `labeled` イベントが短時間に連発し、`pr-policy-check.yml` の required status check が一時的に `expected`（未充足）扱いになりマージがブロックされる
+
+**対応内容**:
+- 根本原因を GitHub Actions の concurrency デフォルト挙動（`queue: single`）と特定。`queue: single` は pending run を 1 つしか保持せず、`labeled`/`unlabeled` 連発時に古い pending run が cancel され、その CANCELLED check run が required status check 判定に混入する（先行課題 Issue #438 の CANCELLED check ブロックと同根の挙動）
+- `pr-policy-check.yml` の `concurrency` に `queue: max` を追加（Issue #485 / PR #486）。pending run を cancel せず FIFO で順次実行させる。`queue: max` は `cancel-in-progress: false` と併用可能（`cancel-in-progress: true` との併用のみ validation error）
+- ラベル判定は `gh pr view` で最新ラベルを都度再取得しているため、古い payload の run が後から実行されても判定結果は変わらない
+- `cancel-in-progress: true` を使う `pr-check.yml`（重い CI。新 SHA で安全に上書きできる）には `queue: max` を追加しない
+
+**成果**: idp-golden-path / terraform-hannibal / ticket-c2c-platform の 3 リポジトリ同一構成に横展開し、ラベルを 11 回連続で付け外しする実地検証（3 リポジトリ合計 47 run）で CANCELLED 0 件を確認。required check の一時 `expected` 化が解消
+
+**学び**: required status check の判定は同名 check run の履歴全体を評価対象にするため、concurrency による run の cancel が「軽量ジョブでも」マージブロックの原因になり得る。concurrency は `cancel-in-progress` だけでなく `queue` の挙動まで含めて、ジョブが冪等か（古い run を捨ててよいか）で選ぶ


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
PR 作成 helper のラベル連続付与で `pull_request.labeled` が連発し、concurrency デフォルト（`queue: single`）が `pr-policy-check.yml` の pending run を cancel した結果 required check が一時的に `expected` 扱いになる問題（#485 / PR #486 で `queue: max` を追加して対応済み）を、運用ドキュメントに記録する。現状 `pr-policy-check.yml` 内の YAML コメントにしか残っていない。

## 変更内容（推奨）
- `docs/troubleshooting/README.md`: 既存のケーススタディ形式でエントリ #6 を追記
- `docs/operations/quality-gates.md`: PR workflow 分割の concurrency 説明に `cancel-in-progress: false` + `queue: max` の経緯・根本原因・検証結果を追記

## 影響範囲（推奨）
- **対象**: `docs/troubleshooting/README.md`、`docs/operations/quality-gates.md`
- **非対象**: workflow / terraform / scripts（コード変更なし）

## PRラベル（必須）
- **type**: `type:docs`
- **area**: `area:docs`, `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
No-op（適用外。docs のみ）。記録内容の実地検証は #485 / PR #486 で 3 リポジトリ合計 47 run・CANCELLED 0 件を確認済み。

## ロールバック *条件付き*
docs 追記のみのため revert で戻せる。運用挙動への影響はない。

## リリース連携（推奨）
- **リリースノート**: 不要

## メモ（レビューポイント）
troubleshooting は既存 #1〜#5 の「課題 / 対応内容 / 成果 / 学び」形式に揃えた。quality-gates は PR workflow 分割セクション（`queue: single` デフォルト挙動の説明箇所）に追記した。

Closes #487


Closes #487
