### PR TITLE
feat: リポジトリルートに catalog-info.yaml を追加する

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,30 @@
+# Backstage Software Catalog の Component 定義（source of truth）。
+#
+# idp-golden-path が GitHub URL location（backstage/app-config.yaml の catalog.locations）
+# 経由でこのファイルを取り込む。所有権はこのリポジトリ側にあり、
+# メタデータの変更はこのリポジトリの通常の PR レビューを通る。
+# 経緯: https://github.com/kmryst/idp-golden-path/issues/91
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform-hannibal
+  description: >-
+    Terraform / AWS / GitHub Actions による ECS Fargate 基盤と
+    Issue → PR → CI の変更管理ガードレールを構築した IaC ポートフォリオ
+  annotations:
+    github.com/project-slug: kmryst/terraform-hannibal
+  links:
+    - url: https://github.com/kmryst/terraform-hannibal
+      title: GitHub Repository
+    - url: https://zenn.dev/kmryst
+      title: Zenn (技術記事)
+  tags:
+    - terraform
+    - aws
+    - ecs
+    - github-actions
+spec:
+  type: infrastructure
+  lifecycle: production
+  owner: platform
+  system: kmryst-portfolio


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）
Backstage Catalog の Component 定義について、idp-golden-path 側の `catalog/portfolio.yaml` による代筆をやめ、このリポジトリ自身が catalog-info.yaml を所有する形にするため。

## 変更内容（推奨）
リポジトリルートに `catalog-info.yaml`（Component 定義）を新規追加。

## 影響範囲（推奨）
- **対象**: `catalog-info.yaml`（新規ファイル）
- **非対象**: terraform/**、workflows、既存アプリケーションの挙動

## PRラベル（必須）
- **type**: `type:feature`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*
No-op（適用外）。docs 追加のみで実行時挙動への影響なし。

## ロールバック *条件付き*
軽運用のため必須ではないが、`catalog-info.yaml` を削除すれば元の状態に戻る。

## リリース連携（推奨）
- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

- YAML 構文が正しいことを目視確認済み
- idp-golden-path 側の GitHub URL location からこのファイルを読み込む形での動作確認は、idp-golden-path #92 の対応内で実施する

</details>

## メモ（レビューポイント）
type/lifecycle/system の値が実態（ECS Fargate 基盤の IaC ポートフォリオ、運用中）に沿っているかご確認ください。

Closes #489


Closes #489
