### PR TITLE
chore: Terraform state関連ファイルのgitignore設定を強化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,18 @@ lerna-debug.log*
 *.tfvars
 *.tfvars.json
 
+# Terraform state（リモートstateバックエンドを使うため、ローカルにstateファイルが
+# 生成されるのは異常系のみだが、誤コミットを防ぐため明示的に除外する。Issue #507）
+*.tfstate
+*.tfstate.*
+.terraform.tfstate.lock.info
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
 # Build analysis
 stats.html
 .github_all_files.txt


### PR DESCRIPTION
## 目的（推奨）
`.gitignore`に`*.tfstate`パターンがなく、Terraformのstateファイルを誤ってコミットしてしまう可能性を防ぐ仕組みがなかった。Gitleaks検出ルール修正（Issue #505）の調査中に判明した軽量なハードニング項目。

## 変更内容（推奨）
`.gitignore`に標準的なTerraform state除外パターンを追加する。

- `*.tfstate` / `*.tfstate.*`
- `.terraform.tfstate.lock.info`
- `crash.log` / `crash.*.log`
- `override.tf` / `override.tf.json` / `*_override.tf` / `*_override.tf.json`

## 影響範囲（推奨）
- **対象**: `.gitignore`のみ
- **非対象**: 現在git追跡されているstateファイルはないため、既存の追跡対象ファイルへの影響なし

## PR ラベル（必須）
- **type**: type:chore
- **area**: area:infra
- **risk**: risk:low
- **cost**: cost:none

<details>
<summary>影響メモ（必要時のみ）</summary>

**コスト根拠**: 追加コストなし
**リスク根拠**: `.gitignore`への追加のみで既存の追跡ファイルには影響しない（`git ls-files | grep -iE "\.tfstate|crash\.log|override\.tf"`で追跡対象がないことを事前確認済み）
**データ影響**: なし
**ロールバック観点**: 本PRをrevertし追加分を削除する

</details>

## 可観測性/検証 *条件付き*
`git ls-files | grep -iE "\.tfstate|crash\.log|override\.tf"`で、追加パターンに該当する追跡対象ファイルが存在しないことを事前に確認済み。

## ロールバック *条件付き*
本PRをrevertする。

## メモ（レビューポイント）
- Issue #505（gitleaks.toml修正）の調査中に判明した副次的な発見への対応です

Closes #507


Closes #507
