### PR TITLE
fix(backend): pin transitive ws to patched version via override

### DIFF
--- a/docs/operations/dependency-management.md
+++ b/docs/operations/dependency-management.md
@@ -47,7 +47,8 @@ Node.js は `>=24 <25` を application runtime / CI / container の support cont
 | `multer@2.2.0` | `@nestjs/platform-express` のexact dependency | file uploadは未使用。advisoryと上流更新を追跡する（Issue #514でDoS脆弱性2件を解消） |
 | `cors@2.8.6` | `@nestjs/platform-express` のexact dependency | direct dependencyにせず、preflightをE2Eで確認する |
 | `lodash@4.18.1` | Nest Config / GraphQLの上流依存 | advisory解消版であることをauditで確認する |
-| `graphql-ws@6.0.8` / `ws@8.20.1` | Nest GraphQLの上流依存 | subscriptions未使用。advisoryと上流更新を追跡する |
+| `graphql-ws@6.0.8` / `ws@8.21.0`（`package.json` の `overrides` で固定） | Nest GraphQLの上流依存 | subscriptions未使用。`@nestjs/graphql@13.4.2` は `ws@8.20.1`（脆弱、GHSA-96hv-2xvq-fx4p）を厳密ピン留めしており、13.4.2が現時点で最新の安定版のため上流修正待ちができない。`overrides` で `@nestjs/graphql` 配下の `ws` のみ `8.21.0`（パッチ済み）に固定する（Issue #515）。`@nestjs/graphql` のバージョン自体は変更しない |
+| `subscriptions-transport-ws@0.11.0` / `ws@7.5.11` | `@nestjs/graphql` の推移的依存 | `ws@^7` のみ対応（8.x非対応）のため、上記 `ws` overrideの対象から明示的に除外し `7.5.11`（既にパッチ済み）に固定する。ネストした `overrides` の書き方は `package.json` を参照 |
 | `glob@10.5.0` | TypeORM `^10.5.0`から解決 | deprecated warningをTypeORM 1評価時に再確認する |
 
 ## Known Peer Warning Allowlist

--- a/package-lock.json
+++ b/package-lock.json
@@ -12294,9 +12294,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -88,5 +88,13 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "overrides": {
+    "@nestjs/graphql": {
+      "ws": "8.21.0",
+      "subscriptions-transport-ws": {
+        "ws": "7.5.11"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 目的（推奨）
Dependency Audit導入（Issue #510）で検出され、Issue #514の対応後も残っていた3件の高リスク脆弱性（`@nestjs/graphql` / `@nestjs/apollo` の推移的依存である `ws@8.20.1`、GHSA-96hv-2xvq-fx4p）を、メジャーバージョンを変更せずに解消する。

## 変更内容（推奨）
- `package.json` に `overrides` を追加し、`@nestjs/graphql` 配下の `ws` をパッチ済みの `8.21.0` に固定
- `subscriptions-transport-ws`（`ws@^5 || ^6 || ^7` のみ対応）配下の `ws` は上記overrideの対象から明示的に除外し、7.x系で既にパッチ済みの `7.5.11` に固定
  - `@nestjs/graphql@13.4.2` は現時点で最新の安定版で、`ws@8.20.1` を厳密ピン留めしているため上流修正を待てない
- `docs/operations/dependency-management.md` のTransitive Dependencies表を更新し、override機構と経緯を明記

## 影響範囲（推奨）
- **対象**: `package.json`（`overrides` フィールドの新規追加のみ、direct dependencyの宣言自体は不変）、`package-lock.json`、`docs/operations/dependency-management.md`
- **非対象**: direct dependencyのバージョン宣言、アプリケーションコード

## PR ラベル（必須）
- **type**: type:bug
- **area**: area:backend
- **risk**: risk:medium
- **cost**: cost:none

<details>
<summary>影響メモ（必要時のみ）</summary>

**コスト根拠**: 追加コストなし
**リスク根拠**: 推移的依存のバージョンを `overrides` で固定する変更であり、direct dependencyの宣言は変わらないが、GraphQL subscription周りのruntime動作に影響し得るため `risk:medium` とする。実機能検証（後述）で回帰がないことを確認済み
**データ影響**: なし
**ロールバック観点**: 本PRをrevertし `package-lock.json` を元に戻す

</details>

## 可観測性/検証 *条件付き*
- `npm ls ws` で解決結果を確認: `@nestjs/graphql` 配下は `ws@8.21.0`（overridden）、`subscriptions-transport-ws` 配下は `ws@7.5.11`（overridden）
- `npm audit` → 0 vulnerabilities
- `npm run build` → 成功
- `npm test` → 15/15 成功
- 実機能検証: 使い捨ての `postgres:16-alpine` コンテナを起動し、ビルド済みアプリを実行。`/graphql` エンドポイントへ実際にHTTPリクエストを送信し、introspectionクエリ、`mutation { seedRoutes }`、`{ routes { id name } }` クエリを実行してデータが正しく投入・取得できることを確認。検証後はコンテナ・一時 `.env`・ログファイルを削除済み

## ロールバック *条件付き*
本PRをrevertする。`overrides` を除去すれば `@nestjs/graphql` が宣言する `ws@8.20.1` に戻る。

<details>
<summary>テスト結果/検証手順</summary>

```
npm ls ws
# └─┬ @nestjs/graphql@13.4.2
#   ├─┬ graphql-ws@6.0.8
#   │ └── ws@8.21.0 deduped
#   ├─┬ subscriptions-transport-ws@0.11.0
#   │ └── ws@7.5.11 overridden
#   └── ws@8.21.0 overridden

npm audit      # found 0 vulnerabilities
npm run build  # 成功
npm test       # Test Suites: 4 passed, Tests: 15 passed
```

</details>

## メモ（レビューポイント）
- `package.json` の direct dependency 宣言（`dependencies`/`devDependencies`）に変更がないことを確認してください
- `overrides` のネスト構造（`subscriptions-transport-ws` を個別に再ピン留めしている点）が正しく機能していることは `npm ls ws` の出力で確認済みです

Closes #515


Closes #515
