### PR TITLE
chore(ci): Dependabotにnpm ecosystemのversion updatesを追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,45 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # root（NestJS backend）。devDependencies は npm-dev グループに集約し、
+  # production 依存は個別 PR のまま残す（idp-golden-path の root エントリと同じ構成）
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dev:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  # client/（React frontend）。root とは独立した npm プロジェクト（client/package-lock.json）
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      # react / react-dom と @types/react* は密結合しており、単独更新すると
+      # 相方が取り残されて CI が壊れる（idp-golden-path PR #53 / #54 / #56 で発生）。
+      # Dependabot は「複数グループにマッチする依存は最初にマッチしたグループに入る」
+      # （first-match-wins）ため、@types/react* を npm-dev ではなく react グループに
+      # 入れるべく、react グループを npm-dev より前に置く
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      npm-dev:
+        dependency-type: "development"
+        patterns:
+          - "*"


### PR DESCRIPTION
## 目的（推奨）

`.github/dependabot.yml` は現在 `github-actions` ecosystem のみで、npm は Dependabot alert 起因の security update しか動かず、transitive 依存の更新 PR を作れない。npm の version updates を追加し、root / client の依存更新を週次で自動追従できるようにする。

## 変更内容（推奨）

- `.github/dependabot.yml` に npm ecosystem のエントリを 2 つ追加
  - root `/`: weekly monday 09:15 Asia/Tokyo、`open-pull-requests-limit: 5`、devDependencies を `npm-dev` グループ（`dependency-type: "development"`、patterns `*`）に集約
  - `/client`: 同 schedule / limit。`react` グループ（react / react-dom / @types/react / @types/react-dom）を `npm-dev` より前に配置（first-match-wins。React 密結合依存の単独更新で CI が壊れた前例: idp-golden-path PR #53 / #54 / #56）
- 既存の github-actions エントリは変更なし

## 影響範囲（推奨）

- **対象**: Dependabot の version updates 設定のみ
- **非対象**: CI workflow（`.github/workflows/**`）、依存関係の実体（package.json / lockfile）、Terraform / AWS リソース

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` で YAML として妥当なことを確認済み（エントリ構成: github-actions `/`、npm `/`、npm `/client`）
- 反映確認は次回 schedule 実行（月曜 09:15 JST）または GitHub Web UI の Dependabot 画面から "Check for updates" を手動実行（ユーザー作業）

## ロールバック *条件付き*

軽運用のため必須ではない。必要時は追加した npm エントリ 2 つを削除して revert すれば従来の github-actions のみの構成に戻る。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- `/client` の `react` グループが `npm-dev` より前にあること（first-match-wins の順序制約）
- groups は既存 open PR の recreate では反映されないため、反映には Web UI の "Check for updates" が必要（ユーザーが手動実施）


Closes #529
