### PR TITLE
chore(ci): DependabotのnpmグループからTypeScriptのmajorを一時除外する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,17 @@ updates:
         dependency-type: "development"
         patterns:
           - "*"
+    ignore:
+      # TypeScript 6.1 以降は @typescript-eslint/eslint-plugin が未対応。
+      # 実測: 8.66.0（最新）の peer は typescript ">=4.8.4 <6.1.0"。
+      # 影響: root は npm ci が ERESOLVE で失敗（PR #537）、
+      #       client は TS5108 esModuleInterop 廃止でビルド失敗（PR #532、client/tsconfig.json:8）。
+      # 本番影響なし: typescript は devDependency でビルド時のみ。
+      # 解除条件: @typescript-eslint/eslint-plugin の peer から <6.1.0 の上限が外れたら。
+      # 見直し期限: 2026-11-02（idp-golden-path #134 / #146 の棚卸し時期と揃える）
+      # 追跡: Issue #542
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # client/（React frontend）。root とは独立した npm プロジェクト（client/package-lock.json）
   - package-ecosystem: "npm"
@@ -54,3 +65,14 @@ updates:
         dependency-type: "development"
         patterns:
           - "*"
+    ignore:
+      # TypeScript 6.1 以降は @typescript-eslint/eslint-plugin が未対応。
+      # 実測: 8.66.0（最新）の peer は typescript ">=4.8.4 <6.1.0"。
+      # 影響: root は npm ci が ERESOLVE で失敗（PR #537）、
+      #       client は TS5108 esModuleInterop 廃止でビルド失敗（PR #532、client/tsconfig.json:8）。
+      # 本番影響なし: typescript は devDependency でビルド時のみ。
+      # 解除条件: @typescript-eslint/eslint-plugin の peer から <6.1.0 の上限が外れたら。
+      # 見直し期限: 2026-11-02（idp-golden-path #134 / #146 の棚卸し時期と揃える）
+      # 追跡: Issue #542
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 目的（推奨）

Dependabot の `npm-dev` グループ PR に TypeScript の major 更新（→ 7.0.2）が混入し、root は `npm ci` の ERESOLVE（PR #537）、client は TS5108 `esModuleInterop` 廃止のビルドエラー（PR #532）で CI が失敗している。同グループに同梱された無害な更新（root 19件・client 5件）まで巻き添えで止まっているため、TypeScript の major のみを一時除外して他を通す。

## 変更内容（推奨）

- `.github/dependabot.yml` の root `/` と `/client` の npm エントリに、`typescript` の `version-update:semver-major` ignore を追加（各 +11 行、計 +22 行）
- コメントに理由・実測値（`@typescript-eslint/eslint-plugin@8.66.0` の peer は `typescript ">=4.8.4 <6.1.0"`、`npm view` で実測）・本番影響なし（devDependency）・解除条件・見直し期限（2026-11-02）・追跡 Issue #542 を明記（idp-golden-path の jsdom ignore コメント規約に準拠）
- typescript の公開版は 6.0.2 / 6.0.3 / 7.0.2 のため、`version-update:semver-major` で 6 系・7 系の両方を抑止できる

## 影響範囲（推奨）

- **対象**: Dependabot の version updates 対象選定のみ（TypeScript の minor / patch 更新は引き続き対象）
- **非対象**: CI workflow（`.github/workflows/**`）、依存関係の実体（package.json / lockfile）、Dependabot security updates（ignore は version updates の抑止であり、alert 起因の security update には別扱い）、Terraform / AWS リソース

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` で YAML として妥当・両 npm エントリに ignore が入っていることを確認済み
- 次回 Dependabot 実行（または Web UI の "Check for updates"）で、TypeScript を含まない `npm-dev` グループ PR が再生成され CI green になることを確認する

## ロールバック *条件付き*

軽運用のため必須ではない。必要時は ignore ブロック 2 箇所を削除して revert すれば従来の挙動に戻る。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- ignore は恒久化させない。解除条件（`@typescript-eslint/eslint-plugin` の peer 上限 `<6.1.0` の撤廃）と見直し期限は #542 で追跡する（#542 は本 PR で close しない）

Refs #542


Closes #543
