### PR TITLE
chore(ci): DependabotのnpmグループからESLintのmajorを一時除外する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,18 @@ updates:
       # 追跡: Issue #542
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # ESLint v9 で flat config が既定になり、v10 で eslintrc 形式のサポートが削除された。
+      # 本リポジトリは .eslintrc.js（旧形式）のままで flat config 未移行。
+      # 実測: PR #546 の Backend Lint & Build / Backend Test が
+      #       「ESLint: 10.8.0 / ESLint couldn't find an eslint.config.(js|mjs|cjs) file.」で失敗。
+      # 本番影響なし: eslint は devDependency で lint 時のみ。
+      # 解除条件: flat config（eslint.config.js）への移行完了時にこの ignore を削除する
+      #           （上流対応待ちではなく、本リポジトリ自身の移行作業が解除条件）。
+      # 見直し期限: 2026-11-02（typescript ignore / idp-golden-path #134・#146 と揃える）
+      # 追跡: Issue #551
+      # client には ESLint 関連の依存も lint script も存在しないため /client には追加しない。
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   # client/（React frontend）。root とは独立した npm プロジェクト（client/package-lock.json）
   - package-ecosystem: "npm"


### PR DESCRIPTION
## 目的（推奨）

Dependabot の root `npm-dev` グループ PR（#546）に ESLint の major 更新（8.57.1 → 10.8.0）が混入し、`Backend Lint & Build` / `Backend Test` が「`ESLint couldn't find an eslint.config.(js|mjs|cjs) file.`」で失敗している（ESLint v10 は eslintrc 形式のサポートを削除、本リポジトリは `.eslintrc.js` のまま）。同グループに同梱された無害な更新まで巻き添えで止まっているため、ESLint の major のみを一時除外して他を通す。

## 変更内容（推奨）

- `.github/dependabot.yml` の **root `/` エントリの既存 `ignore:` ブロック**に、`eslint` の `version-update:semver-major` を追記（typescript の隣、+12 行）
- コメントは既存の typescript ignore と同じ規約で、理由・実測ログ・本番影響なし（devDependency）・解除条件（flat config 移行完了時に削除。上流対応待ちではなく自前の移行作業）・見直し期限（2026-11-02）・追跡 Issue #551 を明記
- `/client` エントリには追加しない（client には ESLint 関連の依存も lint script も存在しない）
- `dependency-name: "eslint"` は完全一致のため、`eslint-config-prettier` / `eslint-plugin-prettier` / `@typescript-eslint/*` は巻き込まない

## 影響範囲（推奨）

- **対象**: Dependabot の version updates 対象選定のみ（ESLint の minor / patch は引き続き更新対象）
- **非対象**: CI workflow（`.github/workflows/**`）、依存関係の実体（package.json / lockfile）、ESLint 設定ファイル自体（flat config 移行は #551）、Terraform / AWS リソース

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

- PyYAML `safe_load` で構文と ignore の適用位置（root のみ eslint + typescript、client は typescript のみ）を確認済み
- ESLint 8.57.1 に留めた場合の peer 整合を実測確認済み: `eslint-config-prettier@10.1.8` は `eslint >=7.0.0`、`@typescript-eslint/eslint-plugin@8.65.0` / `parser@8.66.0` は `eslint "^8.57.0 || ^9.0.0 || ^10.0.0"`（`npm view` の peerDependencies）
- 次回 Dependabot 実行で ESLint major を含まない `npm-dev` グループ PR が再生成され CI green になることを確認する

## ロールバック *条件付き*

軽運用のため必須ではない。必要時は追記した ignore 1 項目を削除して revert すれば従来の挙動に戻る。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- ignore は恒久化させない。解除条件は本リポジトリ自身の flat config 移行（#551、本 PR では close しない実作業 Issue）

Refs #551


Closes #552
