### PR TITLE
chore(deps): clientをApollo Client 4 / graphql 17へ移行する

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,11 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@apollo/client": "^3.13.4",
-        "graphql": "^16.10.0",
+        "@apollo/client": "^4.2.10",
+        "graphql": "^17.0.2",
         "mapbox-gl": "^3.10.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "rxjs": "^7.8.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
@@ -39,29 +40,25 @@
       "license": "MIT"
     },
     "node_modules/@apollo/client": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.4.tgz",
-      "integrity": "sha512-Ot3RaN2M/rhIKDqXBdOVlN0dQbHydUrYJ9lTxkvd6x7W1pAjwduUccfoz2gsO4U9by7oWtRj/ySF0MFNUp+9Aw==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.10.tgz",
+      "integrity": "sha512-SCHzOEcfInIN9DGZvlDR4F+1zd3954WAy+g8dKwi7mrI09Tdh6YzDH+eXbH0LNpB4de2Qyb53RVKe3Ljv5/bMg==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
         "@wry/equality": "^0.5.6",
         "@wry/trie": "^0.5.0",
         "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
-        "prop-types": "^15.7.2",
-        "rehackt": "^0.1.0",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql": "^16.0.0 || ^17.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -815,7 +812,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1129,7 +1126,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -1285,18 +1282,19 @@
       "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+      "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1304,21 +1302,13 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -1372,7 +1362,9 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -1693,17 +1685,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -1809,14 +1790,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/obug": {
@@ -1953,16 +1926,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -2005,11 +1968,6 @@
         "react": "^19.2.8"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2022,23 +1980,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rehackt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/require-from-string": {
@@ -2090,6 +2031,15 @@
         "@rolldown/binding-openharmony-arm64": "1.2.2",
         "@rolldown/binding-win32-arm64-msvc": "1.2.2",
         "@rolldown/binding-win32-x64-msvc": "1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/saxes": {
@@ -2169,14 +2119,6 @@
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "dependencies": {
         "kdbush": "^4.0.2"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/symbol-tree": {
@@ -2279,17 +2221,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tslib": {
@@ -2580,19 +2511,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "dependencies": {
-        "zen-observable": "0.8.15"
-      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -17,11 +17,12 @@
     "node": ">=24 <25"
   },
   "dependencies": {
-    "@apollo/client": "^3.13.4",
-    "graphql": "^16.10.0",
+    "@apollo/client": "^4.2.10",
+    "graphql": "^17.0.2",
     "mapbox-gl": "^3.10.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",

--- a/client/src/apollo/client.ts
+++ b/client/src/apollo/client.ts
@@ -1,5 +1,5 @@
 // C:\code\javascript\nestjs-hannibal-3\client\src\apollo\client.ts
-import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
 
 // Viteの環境変数からエンドポイントを取得 (プレフィックス 'VITE_' が必要)
 const graphqlUri = import.meta.env.VITE_GRAPHQL_ENDPOINT;
@@ -11,8 +11,12 @@ if (!graphqlUri) {
 
 console.log(`[Apollo Client] Connecting to GraphQL at: ${graphqlUri}`);
 
+// Apollo Client 4 は `uri` ショートハンドを廃止し、`link` を必須オプションにした。
+// 挙動は 3 系の `uri` 指定と等価（内部で HttpLink を生成していた）。
 const client = new ApolloClient({
-   uri: graphqlUri || '/graphql', // 環境変数が未定義の場合のフォールバック例
+   link: new HttpLink({
+     uri: graphqlUri || '/graphql', // 環境変数が未定義の場合のフォールバック例
+   }),
    cache: new InMemoryCache(),
  });
 

--- a/client/src/components/MapContainer.test.tsx
+++ b/client/src/components/MapContainer.test.tsx
@@ -15,6 +15,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@apollo/client', () => ({
   gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+// Apollo Client 4 で React 向けの export は '@apollo/client/react' へ移動した
+vi.mock('@apollo/client/react', () => ({
   useQuery: mocks.useQuery,
 }));
 

--- a/client/src/components/MapContainer.tsx
+++ b/client/src/components/MapContainer.tsx
@@ -1,7 +1,9 @@
 // C:\code\javascript\nestjs-hannibal-3\client\src\components\MapContainer.tsx
 
 import { useEffect, useRef, useState } from "react";
-import { useQuery, gql } from "@apollo/client";
+import { gql } from "@apollo/client";
+// Apollo Client 4 で React 向けの export は '@apollo/client/react' へ移動した
+import { useQuery } from "@apollo/client/react";
 import {
   initializeMap,
   setTerrain,
@@ -12,6 +14,18 @@ import {
   addCapitalCityLayers,
 } from "../services/mapLayers";
 import { setupClickHandlers, setupCursorHandlers } from "../utils/mapUtils";
+import type * as GeoJSON from "geojson";
+
+// Apollo Client 4 の useQuery は TData の既定値が any ではなくなったため、
+// GET_MAP_DATA の戻り値型を明示する。実行時の挙動は 3 系と同じ。
+type GetMapDataQuery = {
+  capitalCities: GeoJSON.FeatureCollection<
+    GeoJSON.Point,
+    { empire: string; name: string }
+  >;
+  hannibalRoute: GeoJSON.FeatureCollection<GeoJSON.LineString>;
+  pointRoute: GeoJSON.FeatureCollection<GeoJSON.Point>;
+};
 
 // GraphQLクエリ
 const GET_MAP_DATA = gql`
@@ -65,7 +79,7 @@ const MapContainer: React.FC = () => {
   const mapRef = useRef<any>(null);
   const [progress, setProgress] = useState(0);
   const [isMapboxLoading, setIsMapboxLoading] = useState(true);
-  const { loading, error, data } = useQuery(GET_MAP_DATA);
+  const { loading, error, data } = useQuery<GetMapDataQuery>(GET_MAP_DATA);
 
   // Mapboxの動的インポート
   // 初期バンドルサイズを削減するため、Mapboxを動的に読み込む

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -29,7 +29,8 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ApolloProvider } from '@apollo/client';
+// Apollo Client 4 で React 向けの export は '@apollo/client/react' へ移動した
+import { ApolloProvider } from '@apollo/client/react';
 import client from './apollo/client';
 import App from './App';
 import './index.css';

--- a/docs/operations/dependency-management.md
+++ b/docs/operations/dependency-management.md
@@ -61,7 +61,7 @@ root と client は独立した npm プロジェクトであり、両者の通�
 
 この点は推論だけで済ませず、Issue #566 の移行時にローカル実測しています。Docker 上の PostgreSQL 16 で backend（graphql 16.14.2）を起動し、client（graphql 17.0.2 / Apollo Client 4.2.10）を dev server と production build の双方から実ブラウザで開き、`GetMapData` クエリが 200 で成功して地図レイヤーが描画されること、コンソールに Apollo / GraphQL 由来のエラーが出ないことを確認しました。
 
-root 側の graphql major 更新の扱いは Issue #564 / PR #565 で別途整理します。
+root 側の graphql major 更新は、PR #565 で Dependabot の ignore に追加して抑止済みです（root `/` のみが対象で `/client` は対象外）。解除条件と見直し期限は後述の「有効な Dependabot ignore」表を、追跡は Issue #564 を参照してください。
 
 ## Transitive Dependencies
 
@@ -98,7 +98,7 @@ root の `npm ls --all` で許容する非zero要因は、`@nestjs/apollo@13.4.2
 | `typescript` | major | root `/` と `/client` | `@typescript-eslint/eslint-plugin@8.66.0` の peer が `typescript ">=4.8.4 <6.1.0"`。root は `npm ci` が ERESOLVE で失敗（PR #537）、client は TS5108 `esModuleInterop` 廃止でビルド失敗（PR #532）。devDependency のため本番影響なし | `@typescript-eslint/eslint-plugin` の peer から `<6.1.0` の上限が外れたら（上流待ち） | 2026-11-02 | [Issue #542](https://github.com/kmryst/terraform-hannibal/issues/542) |
 | `eslint` | major | root `/` のみ | ESLint v9 で flat config が既定、v10 で eslintrc 形式のサポートが削除された。本リポジトリは `.eslintrc.js` のままで未移行のため、`ESLint couldn't find an eslint.config.(js\|mjs\|cjs) file.` で lint が失敗（PR #546）。devDependency のため本番影響なし。client には ESLint 関連の依存も lint script もないため `/client` には追加しない | flat config（`eslint.config.js`）への移行完了（上流待ちではなく本リポジトリ自身の作業） | 2026-11-02 | [Issue #551](https://github.com/kmryst/terraform-hannibal/issues/551) |
 | `@types/node` | major | root `/` のみ | runtime major と型定義 major を一致させる contract（前節「現行 Backend Contract」）。runtime は Node 24（`node:24-alpine` / `engines >=24 <25`）のため、26 系型定義は「runtime に存在しない API が型チェックを通る」リスクがある（PR #554 で 26.1.2 が提案された）。devDependency のため本番影響なし | Node runtime の major 更新（`node:24-alpine` / `setup-node` / `engines`）と同時に外す | 2026-11-02 | [Issue #555](https://github.com/kmryst/terraform-hannibal/issues/555) |
-| `graphql` | major | root `/` のみ | `@apollo/server@5.5.1` と `@nestjs/graphql@13.4.2`（いずれも 2026-08-06 時点で npm latest）の peer がどちらも `graphql "^16.11.0"` で、graphql 17 を受け付けない。root は `npm ci` が ERESOLVE で失敗（PR #541）。production dependency のため `--force` / `--legacy-peer-deps` による強制解決はしない。client 側（PR #533）は `@apollo/client` を 4 系へ上げれば通せる（`3.13.4` の peer は `graphql "^15.0.0 \|\| ^16.0.0"`、`4.2.9` は `"^16.0.0 \|\| ^17.0.0"`）ため `/client` には追加しない | `@apollo/server` と `@nestjs/graphql`（または後継 major）の peer が `graphql ^17` を許容したら（上流待ち） | 2026-11-02 | [Issue #564](https://github.com/kmryst/terraform-hannibal/issues/564) |
+| `graphql` | major | root `/` のみ | `@apollo/server@5.5.1` と `@nestjs/graphql@13.4.2`（いずれも 2026-08-06 時点で npm latest）の peer がどちらも `graphql "^16.11.0"` で、graphql 17 を受け付けない。root は `npm ci` が ERESOLVE で失敗（PR #541）。production dependency のため `--force` / `--legacy-peer-deps` による強制解決はしない。client 側は `@apollo/client` を 4 系へ上げることで graphql 17 を通せるため `/client` には追加しない（`3.13.4` の peer は `graphql "^15.0.0 \|\| ^16.0.0"`、`4.2.10` は `"^16.0.0 \|\| ^17.0.0"`）。この移行は Issue #566 / PR #567 で完了しており、client は `@apollo/client@4.2.10` / `graphql@17.0.2` で稼働している（前節「現行 Frontend Contract」参照）。したがって client 側に ignore は不要な状態が続いている | `@apollo/server` と `@nestjs/graphql`（または後継 major）の peer が `graphql ^17` を許容したら（上流待ち） | 2026-11-02 | [Issue #564](https://github.com/kmryst/terraform-hannibal/issues/564) |
 
 ## Follow-up Issue Plans
 

--- a/docs/operations/dependency-management.md
+++ b/docs/operations/dependency-management.md
@@ -42,6 +42,27 @@ Node.js は `>=24 <25` を application runtime / CI / container の support cont
 
 TypeORM 1.1.0 への更新（PR #547）は、Docker 上の PostgreSQL 16 に対するスモークテスト（アプリ起動、`synchronize` によるスキーマ自動生成、GraphQL 経由の createRoute / routes / seedRoutes の成功）と unit test を検証済みです。AWS dev 環境での実地 CRUD 確認は未了であり、次回 `deploy.yml`（workflow_dispatch）実行時に行います。
 
+## 現行 Frontend Contract
+
+`client/` は root とは独立した npm プロジェクトです。前節の Backend Contract は root（NestJS backend）のみを対象とし、client の依存は以下を正本とします。
+
+| 領域 | 採用 version | 用途・制約 | 再検討条件 |
+|---|---:|---|---|
+| Apollo Client | `4.2.10` | React frontend の GraphQL client。4 系で React 向け export が `@apollo/client` から `@apollo/client/react` へ移動し、`ApolloClient` の `uri` ショートハンドが廃止されて `link` が必須になった | 5 系 stable と React 対応後 |
+| GraphQL.js | `17.0.2` | `@apollo/client@4` の peer が `^16.0.0 \|\| ^17.0.0` で 17 を許容する。root（backend）は Apollo Server / Nest GraphQL の peer 制約により 16 系のまま据え置く | root 側が 17 へ揃った時点で両者の major 一致を再検討 |
+| rxjs | `7.8.2` | `@apollo/client@4` の**必須** peer（`^7.3.0`、`peerDependenciesMeta` で optional 指定されていない）。3 系が dependencies に持っていた `zen-observable-ts` の置き換え先。アプリケーションコードから直接 import はしないが、宣言を省くと peer 未充足になる | Apollo Client が Observable 実装を変更した場合 |
+| React / React DOM | `19` 系 | `@apollo/client@4` の peer は `>=19.0.0-rc` を許容する | React 20 stable と Apollo Client 対応後 |
+
+`@apollo/client@4.2.10` の peer のうち `react` / `react-dom` / `graphql-ws` / `subscriptions-transport-ws` は `peerDependenciesMeta` で optional です。client は GraphQL subscription を使わないため、`graphql-ws` / `subscriptions-transport-ws` は導入しません。
+
+### root（GraphQL 16）と client（GraphQL 17）の major 分岐
+
+root と client は独立した npm プロジェクトであり、両者の通信は GraphQL over HTTP です。GraphQL.js のバージョンは各プロセス内のスキーマ構築・クエリ実行の実装詳細であり、ワイヤ上でやり取りされるのは HTTP + JSON のリクエスト / レスポンスのため、major が分かれても通信要件には影響しません。
+
+この点は推論だけで済ませず、Issue #566 の移行時にローカル実測しています。Docker 上の PostgreSQL 16 で backend（graphql 16.14.2）を起動し、client（graphql 17.0.2 / Apollo Client 4.2.10）を dev server と production build の双方から実ブラウザで開き、`GetMapData` クエリが 200 で成功して地図レイヤーが描画されること、コンソールに Apollo / GraphQL 由来のエラーが出ないことを確認しました。
+
+root 側の graphql major 更新の扱いは Issue #564 / PR #565 で別途整理します。
+
 ## Transitive Dependencies
 
 | Package | Owner / 制約 | 確認事項 |


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）

client（React frontend）の `@apollo/client` を 4 系、`graphql` を 17 系へ移行する。

Dependabot が上げている 2 本はどちらも単独ではマージできない。`@apollo/client@3.13.4` の peer は `graphql "^15.0.0 || ^16.0.0"` で graphql 17 を受け付けず、`4.2.9` は `"^16.0.0 || ^17.0.0"` のため順序依存がある。Dependabot の PR は `package.json` の 1 行しか書き換えられず、コード修正も依存追加もできないため、この 2 本は原理的にマージできない。

- PR #534 `@apollo/client` 3.13.4 → 4.2.9: Frontend Build が TS エラーで失敗
- PR #533 `graphql` 16.11.0 → 17.0.2: `npm ci` が ERESOLVE で失敗

この PR は上記 2 本を **supersede** する。マージ後に #534 / #533 を「superseded by」コメント付きで close する（この PR では close しない）。

## 変更内容（推奨）

**`client/package.json`**

| 依存 | before | after | 根拠 |
|---|---|---|---|
| `@apollo/client` | `^3.13.4` | `^4.2.10` | 4 系の最新 stable（`npm view @apollo/client dist-tags` で `latest: 4.2.10` を確認。#534 提案の 4.2.9 より新しい） |
| `graphql` | `^16.10.0` | `^17.0.2` | `npm view graphql dist-tags` で `latest: 17.0.2` |
| `rxjs` | （なし） | `^7.8.2` | **追加**。`@apollo/client@4` の必須 peer |

`rxjs` を追加した根拠（`npm view @apollo/client@4.2.9 peerDependencies peerDependenciesMeta` の実測）:

- `peerDependencies` は `rxjs ^7.3.0` / `graphql ^16.0.0 || ^17.0.0` / `react` / `react-dom` / `graphql-ws` / `subscriptions-transport-ws`
- `peerDependenciesMeta` で `optional: true` なのは `react` / `react-dom` / `graphql-ws` / `subscriptions-transport-ws` の 4 つのみ
- したがって **`rxjs` と `graphql` は optional ではない**。v3 が dependencies に持っていた `zen-observable-ts` が v4 で rxjs へ置き換わったため、宣言の追加が必要

`graphql-ws` / `subscriptions-transport-ws` は optional peer であり、client は subscription を使わないため導入しない。

**コード**

- `client/src/apollo/client.ts`: `ApolloClient` の `uri` ショートハンドが 4 系で廃止され `link` が必須になったため、`HttpLink` を明示。3 系は内部で同じ HttpLink を生成していたので挙動は等価
- `client/src/main.tsx`: `ApolloProvider` の import 元を `@apollo/client` → `@apollo/client/react`
- `client/src/components/MapContainer.tsx`: `useQuery` の import 元を `@apollo/client/react` へ。加えて 4 系で `useQuery` の `TData` 既定値が `any` でなくなり `data` が `{}` 型になったため、`GET_MAP_DATA` の戻り値型 `GetMapDataQuery` を明示（型のみの変更で実行時の挙動は変わらない）
- `client/src/components/MapContainer.test.tsx`: export 移動に合わせて `vi.mock('@apollo/client/react')` を追加

**lockfile**

`client/package-lock.json` を段階的更新（`npm install --no-audit @apollo/client@^4.2.10 graphql@^17.0.2 rxjs@^7.8.2`）で追随。削除して全面再生成はしていない。`zen-observable-ts` / `zen-observable` / `ts-invariant` / `symbol-observable` / `rehackt` / `hoist-non-react-statics` 等が消え、`rxjs` が入る（+36 / -118 行）。

**docs**

`docs/operations/dependency-management.md` に「現行 Frontend Contract」節を追加。既存の「現行 Backend Contract」表は root のみを対象とすることを明示し、client 側の Apollo Client / GraphQL.js / rxjs / React の contract と、root（graphql 16）と client（graphql 17）で major が分かれる件の実測結果を記載した。

## 影響範囲（推奨）

- **対象**: `client/` の依存・フロントエンドコード、`docs/operations/dependency-management.md`
- **非対象**: root（NestJS backend）の `package.json` / `package-lock.json`（graphql 16 のまま据え置き）、`mapbox-gl` のバージョン（PR #535 の対象）、`.github/dependabot.yml`（PR #565 の対象）、`terraform/**`、`.github/workflows/**`

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:frontend`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）: なし。frontend の静的アセット差し替えのみで、deploy は S3 sync + CloudFront

**コスト根拠**（小/中/大の場合）: なし（`cost:none`）。AWS リソース構成に変更なし

**リスク根拠**（Medium/Highの場合）: Apollo Client は major 更新であり、GraphQL 通信層そのものを差し替える。ビルドが通っても実行時に壊れうるため `risk:low` にはしない。これに伴い**厳密運用**として扱い、ロールバック欄を実質的に記載する

</details>

## 可観測性/検証 *条件付き*

すべてローカル実測。AWS リソースには一切触れていない。

**1. ビルド / テスト（client）**

- `npm run build`（`tsc && vite build`）: 成功。残る warning は移行前から出ている既存のもの（vite config loader / chunk size / mapbox-gl の INEFFECTIVE_DYNAMIC_IMPORT）のみ
- `npm test`（vitest）: `Test Files 2 passed (2) / Tests 5 passed (5)`
- `rm -rf node_modules && npm ci`: `added 156 packages` / `found 0 vulnerabilities` で成功。`--force` も `--legacy-peer-deps` も使っていない（#533 の ERESOLVE が解消されたことの直接確認）
- `npm ls` で解決版を確認: `@apollo/client@4.2.10` / `graphql@17.0.2` / `rxjs@7.8.2` / `graphql-tag@2.12.7` / `@graphql-typed-document-node/core@3.2.0`。`graphql-tag` は `^2.12.6` の範囲で 17 対応済みの `2.12.7` が選ばれ、peer 競合は起きない

**2. ブラウザでの実動作確認**

Docker の `postgres:16-alpine`（この検証用に起動した専用コンテナ）に対して backend（root、graphql 16.14.2）をローカル起動し、client を実ブラウザ（Playwright / Chrome）で開いて確認した。

- **dev server（`vite`）**: `POST http://localhost:3000/graphql` が **200**。コンソールに `Capital Cities Data: {... features: Array(2)}` / `Hannibal Route Data: {... features: Array(1)} `/ `Point Route Data: {... features: Array(24)}` / `Map layers added successfully.` が出力。Mapbox の 3D 地図上に Roma / Carthage の首都マーカーとハンニバルルートのポイント列が描画されることをスクリーンショットで確認。エラーは favicon の 404 のみで、Apollo / GraphQL 由来のエラーは 0 件
- **production build（`vite build` → `vite preview`）**: 同じクエリが成功し、コンソールは **エラー 0 件 / warning 0 件**。dev の module resolution だけでなく、bundle 後のコードでも Apollo Client 4 の subpath export が正しく解決されることを確認

**3. root（graphql 16）と client（graphql 17）の major 分岐**

上記 2 がそのまま実測になっている。backend は `graphql@16.14.2`、client は `graphql@17.0.2` / `@apollo/client@4.2.10` の組み合わせで、`GetMapData` クエリ（`capitalCities` / `hannibalRoute` / `pointRoute`）が成功した。両者は独立した npm プロジェクトで、ワイヤ上は GraphQL over HTTP（JSON）のため、GraphQL.js の major 差は通信要件に影響しないことを推論ではなく実測で確認した。

**検証環境の後始末**: この検証のために起動した PostgreSQL コンテナ `hannibal-apollo4-verify-pg` は `docker rm -f` で削除済み（`docker ps -a --filter name=hannibal-apollo4-verify` が 0 件）。backend / vite プロセスも停止済み。なお他プロジェクト（ticket-c2c 等）のコンテナは元から稼働しており、それらには触れていない。作業用ファイルは repository 外の scratchpad に置いた。

**未実施**: AWS dev 環境への実デプロイでの確認は行っていない。次回 `deploy.yml`（workflow_dispatch）実行時に確認する。

## ロールバック *条件付き*

frontend の依存とコードのみの変更で、AWS リソース・DB スキーマ・Terraform state に影響しない。

1. この PR を revert する（`gh pr revert` 相当、または `git revert <squash commit>`）
2. `cd client && rm -rf node_modules && npm ci` で `@apollo/client@3.13.4` / `graphql@16.x` 構成へ戻る
3. デプロイ済みの場合は revert 後の `main` から `deploy.yml`（workflow_dispatch）を再実行し、frontend アセットを再配信する

revert 単体で完結し、DB マイグレーションの巻き戻しや手動の AWS 操作は不要。

## リリース連携（推奨）

- **リリースノート**: 要（frontend の GraphQL クライアントの major 更新のため）

<details>
<summary>テスト結果/検証手順</summary>

```text
$ cd client && npm run build
✓ built in 685ms

$ npm test
 Test Files  2 passed (2)
      Tests  5 passed (5)

$ rm -rf node_modules && npm ci
added 156 packages, and audited 157 packages in 7s
found 0 vulnerabilities

$ npm ls @apollo/client graphql rxjs graphql-tag
client@1.0.0
├─┬ @apollo/client@4.2.10
│ ├─┬ graphql-tag@2.12.7
│ │ └── graphql@17.0.2 deduped
│ ├── graphql@17.0.2 deduped
│ └── rxjs@7.8.2 deduped
├── graphql@17.0.2
└── rxjs@7.8.2
```

ブラウザ確認（production build、コンソール出力）:

```text
[LOG] [Apollo Client] Connecting to GraphQL at: http://localhost:3000/graphql
[LOG] Capital Cities Data: {__typename: CapitalCityCollection, type: FeatureCollection, features: Array(2)}
[LOG] Hannibal Route Data: {__typename: HannibalRouteCollection, type: FeatureCollection, features: Array(1)}
[LOG] Point Route Data: {__typename: PointRouteCollection, type: FeatureCollection, features: Array(24)}
[LOG] Map layers added successfully.
→ Errors: 0, Warnings: 0
```

</details>

## メモ（レビューポイント）

- `rxjs` は アプリケーションコードから直接 import しない。`peerDependenciesMeta` に optional 指定がないため宣言が必要、という判断（grep だけでは「未使用」に見える依存）
- `MapContainer.tsx` の `GetMapDataQuery` 型は、3 系の `useQuery` が `TData = any` だったところを型で埋めたもの。GraphQL スキーマ（`src/graphql/schema/map.graphql`）の該当クエリと突き合わせて過不足がないか確認いただきたい
- `@apollo/client` は #534 が提案する `4.2.9` ではなく、npm latest の `4.2.10` を採用した（「選択した supported line の最新 stable を採用する」という `dependency-management.md` の基本方針に沿う）
- `docs/operations/dependency-management.md` は PR #565 も編集している。競合を避けるため、既存の GraphQL.js 行や ignore 表には手を入れず、新しい「現行 Frontend Contract」節の追加のみに留めた

Refs #534
Refs #533


Closes #566
