### PR TITLE
docs: Amazon Q Developer自動レビューの位置づけを運用ドキュメントに明記する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,6 +398,17 @@ terraform plan はレビュー補助として Job Summary と artifact に出力
 
 理由と将来の required 化方針は [docs/operations/github-flow-guardrails.md](./docs/operations/github-flow-guardrails.md) の「Terraform plan の required status check 方針」節を参照してください。
 
+### 自動コードレビュー（Amazon Q Developer）
+
+PR では GitHub App `Amazon Q Developer` による自動コードレビューが実行され、指摘は review comment として投稿されます。
+
+- GitHub App が提供する check であり、`.github/workflows/` 配下の workflow ではありません
+- **required status check には含まれず、マージをブロックしません**
+- マージ前に指摘への対応要否を判断し、対応するか、対応しない理由を明確にしたうえで conversation を Resolve してからマージします
+- Dependabot PR では実行されません。また rebase などの force-push 後は、新しい head commit の check 一覧に表示されない場合があります
+
+位置づけと実測した実行挙動の詳細は [docs/operations/github-flow-guardrails.md](./docs/operations/github-flow-guardrails.md) の「自動コードレビュー（Amazon Q Developer）」節を参照してください。
+
 ---
 
 ## 📋 開発フロー図

--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -59,6 +59,7 @@ Terraform / AWS / SRE 実践としての固有判断はこのリポジトリに�
 - PR title と PR 内コミットメッセージは `Commitlint` job で Conventional Commits 形式を検査する
 - `TFLint` と `Gitleaks Secret Scan` は #228 で required status checks に追加した
 - `Trivy Config Scan` は HIGH / CRITICAL finding を review signal として表示するが、#228 時点では blocking gate にしない
+- GitHub App `Amazon Q Developer` による自動コードレビューを review signal として利用する（詳細は「自動コードレビュー（Amazon Q Developer）」節）
 
 ### 軽運用 / 厳密運用
 
@@ -136,6 +137,22 @@ backend / frontend / Docker / Terraform / TFLint / Trivy / Gitleaks は `.github
 既存の finding には、Dockerfile root user、WAF 無効化、KMS / CMK 系の accepted risk 候補が含まれるため、blocking gate にする前に修正対象・accepted risk・ignore 対象を整理します。
 
 この段階的 required 化の判断背景、代替案、トレードオフは [ADR 0013](../adr/0013-promote-quality-checks-to-required-gradually.md) に記録します。
+
+### 自動コードレビュー（Amazon Q Developer）
+
+PR には GitHub App `Amazon Q Developer`（app slug: `amazon-q-developer`）による自動コードレビューが実行されます。
+
+- GitHub App が提供する check であり、`.github/workflows/` 配下の workflow ではない。リポジトリ内に対応する workflow ファイルは存在しない
+- branch protection の required status checks には含まれない。マージをブロックしない review signal として扱う（`Trivy Config Scan` と同じ位置づけ）
+- 指摘は PR の review comment として投稿される。マージ前に指摘への対応要否を判断し、対応するか、対応しない理由を明確にしたうえで conversation を Resolve してからマージする
+- `.amazonq/rules/` は Amazon Q 向けの補助ルールであり、運用ルールの正本ではない（CLAUDE.md 参照）
+- この App をいつ誰がリポジトリに有効化したかの設定経緯は、リポジトリ内には記録されていない
+
+実行挙動（2026-08-06 時点、check-runs API / reviews API での実測）:
+
+- 人間 / AI Agent が作成した PR では、head commit に check `Amazon Q Developer` が作成され、review comment が投稿される（#544 / #553 / #557 / #562 / #565 で確認）
+- Dependabot が作成した PR では実行されない（#558 / #559 / #560 の head commit に check-run・review とも存在しないことを確認）
+- rebase などの force-push 後は、新しい head commit に check-run が必ずしも再作成されない（#567 で確認。レビュー自体は PR に残るが、check 一覧に `Amazon Q Developer` が表示されなくなる）。PR によって check 一覧に現れたり現れなかったりするのはこのため
 
 ## 未採用案と理由
 
@@ -245,7 +262,7 @@ branch protection の更新は、PR plan の再導入後に gate job が安定�
 `PR Policy Check` は `.github/workflows/pr-policy-check.yml` から、`Commitlint` は `.github/workflows/pr-commitlint.yml` から、その他の PR gate / review signal は `.github/workflows/pr-check.yml` から実行する。
 workflow を分割しても、branch protection が参照する required status check の context 名は変更しない。
 
-`Trivy Config Scan` は required に含まれていない。
+`Trivy Config Scan` と `Amazon Q Developer`（GitHub App による自動コードレビュー、「自動コードレビュー（Amazon Q Developer）」節参照）は required に含まれていない。
 `Terraform Plan Change Detection` / `Terraform Plan Artifact` は #410 で workflow から一時的に削除している。
 
 ### deploy workflow と PR gate の責務分離


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）

GitHub App `Amazon Q Developer` による PR 自動コードレビューが実運用されているにもかかわらず、その存在・位置づけ（required か否か、指摘の扱い）が正本ドキュメントに記載されていないため、正本に明記する。

## 変更内容（推奨）

- `docs/operations/github-flow-guardrails.md`: 「自動コードレビュー（Amazon Q Developer）」節を新設。GitHub App 由来の check であり workflow ではないこと、required status checks に含まれないこと、レビュー指摘の扱い、check-runs API / reviews API で実測した実行挙動（Dependabot PR では実行されない、force-push 後の head commit に check-run が再作成されない場合がある）を記載。「現在の required status checks（参考）」節と採用方針一覧にも非 required である旨を追記
- `CONTRIBUTING.md`: 「✅ CIチェック」節に「自動コードレビュー（Amazon Q Developer）」小節を追加し、guardrails 文書へのリンクを設置

## 影響範囲（推奨）

- **対象**: `CONTRIBUTING.md` / `docs/operations/github-flow-guardrails.md`（ドキュメントのみ）
- **非対象**: `.github/workflows/**`、branch protection 設定、`.github/dependabot.yml`、`.amazonq/**`、アプリケーションコード、Terraform

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`, `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

No-op（Doc-only、適用外）。記載内容は check-runs API / reviews API / branch protection API の実測（PR #544 / #553 / #557 / #558 / #559 / #560 / #562 / #565 / #567）に基づく。markdownlint はローカルで 0 issues を確認済み。

## ロールバック *条件付き*

軽運用 PR のため不要（必要時は本 PR を revert するだけで戻る）。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- required status checks に `Amazon Q Developer` を追加する変更は行っていない（記載のみ）
- App の有効化経緯はリポジトリ内に記録がないため「未記録」と明示し、推測は書いていない


Closes #568
