### PR TITLE
chore(deps): mapbox-glを3.27へ更新しGeoJSON型定義を@types/geojsonの直接依存で解決する

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "^4.2.10",
         "graphql": "^17.0.2",
-        "mapbox-gl": "^3.10.0",
+        "mapbox-gl": "^3.27.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rxjs": "^7.8.2"
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
-        "@types/mapbox-gl": "^3.4.1",
+        "@types/geojson": "^7946.0.16",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^6.0.2",
@@ -329,50 +329,6 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
-      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
-    },
-    "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
-    },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
-    },
-    "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-      "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.142.0",
@@ -769,44 +725,9 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
-    },
-    "node_modules/@types/geojson-vt": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
-      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
-      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA=="
-    },
-    "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
-      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
-      "dependencies": {
-        "@types/geojson": "*",
-        "@types/mapbox__point-geometry": "*",
-        "@types/pbf": "*"
-      }
-    },
-    "node_modules/@types/mapbox-gl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz",
-      "integrity": "sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/pbf": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
-      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -826,14 +747,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "dependencies": {
-        "@types/geojson": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1084,11 +997,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cheap-ruler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
-      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw=="
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1116,11 +1024,6 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1192,11 +1095,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/earcut": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -1271,16 +1169,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/geojson-vt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
-      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
-    },
-    "node_modules/gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
-    },
     "node_modules/graphql": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
@@ -1305,11 +1193,6 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/grid-index": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1322,25 +1205,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -1406,11 +1270,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -1717,39 +1576,17 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.10.0.tgz",
-      "integrity": "sha512-YnQxjlthuv/tidcxGYU2C8nRDVXMlAHa3qFhuOJeX4AfRP72OMRBf9ApL+M+k5VWcAXi2fcNOUVgphknjLumjA==",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.16",
-        "@types/geojson-vt": "^3.2.5",
-        "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "cheap-ruler": "^4.0.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.0",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
-        "grid-index": "^1.1.0",
-        "kdbush": "^4.0.2",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^3.0.0",
-        "serialize-to-js": "^3.1.2",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
-      }
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.27.0.tgz",
+      "integrity": "sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "workspaces": [
+        "src/style-spec",
+        "plugins/mapbox-gl-pmtiles-provider",
+        "test/build/vite",
+        "test/build/webpack",
+        "test/build/typings"
+      ]
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
@@ -1767,11 +1604,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/murmurhash-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
@@ -1837,18 +1669,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pbf": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
-      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
-      "dependencies": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1897,11 +1717,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/potpack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -1926,12 +1741,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
-      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1941,11 +1750,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/quickselect": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -1990,14 +1794,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dependencies": {
-        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rolldown": {
@@ -2061,14 +1857,6 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
-    "node_modules/serialize-to-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
-      "integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2113,14 +1901,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -2161,11 +1941,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/tinyqueue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.1",
@@ -2418,16 +2193,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/vt-pbf": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
-      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
-      "dependencies": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@apollo/client": "^4.2.10",
     "graphql": "^17.0.2",
-    "mapbox-gl": "^3.10.0",
+    "mapbox-gl": "^3.27.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rxjs": "^7.8.2"
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
-    "@types/mapbox-gl": "^3.4.1",
+    "@types/geojson": "^7946.0.16",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^6.0.2",

--- a/docs/operations/dependency-management.md
+++ b/docs/operations/dependency-management.md
@@ -52,6 +52,8 @@ TypeORM 1.1.0 への更新（PR #547）は、Docker 上の PostgreSQL 16 に対�
 | GraphQL.js | `17.0.2` | `@apollo/client@4` の peer が `^16.0.0 \|\| ^17.0.0` で 17 を許容する。root（backend）は Apollo Server / Nest GraphQL の peer 制約により 16 系のまま据え置く | root 側が 17 へ揃った時点で両者の major 一致を再検討 |
 | rxjs | `7.8.2` | `@apollo/client@4` の**必須** peer（`^7.3.0`、`peerDependenciesMeta` で optional 指定されていない）。3 系が dependencies に持っていた `zen-observable-ts` の置き換え先。アプリケーションコードから直接 import はしないが、宣言を省くと peer 未充足になる | Apollo Client が Observable 実装を変更した場合 |
 | React / React DOM | `19` 系 | `@apollo/client@4` の peer は `>=19.0.0-rc` を許容する | React 20 stable と Apollo Client 対応後 |
+| mapbox-gl | `3.27.0` | 地図描画ライブラリ。3 系は型定義（`dist/mapbox-gl.d.ts`）を同梱するため `@types/mapbox-gl` は不要（3.5.0 以降は deprecated stub になっており導入しない）。同梱 d.ts は ambient `GeoJSON` namespace を参照するが `@types/geojson` への依存を宣言していないため、client 側で direct devDependency として持つ | mapbox-gl 4 系 stable 後 |
+| @types/geojson | `7946.0.16` | `geojson` モジュールと ambient `GeoJSON` namespace の供給元。アプリケーションコード（`mapLayers.ts` / `mapUtils.ts` / `MapContainer.tsx`）と mapbox-gl 同梱 d.ts の両方が必要とする。旧 `@types/mapbox-gl@3.4.1` が推移的に供給していたが、stub 化（PR #535 で 3.5.0 へ更新提案）で供給が途切れるため direct 化した | mapbox-gl が型依存を自己完結させた場合 |
 
 `@apollo/client@4.2.10` の peer のうち `react` / `react-dom` / `graphql-ws` / `subscriptions-transport-ws` は `peerDependenciesMeta` で optional です。client は GraphQL subscription を使わないため、`graphql-ws` / `subscriptions-transport-ws` は導入しません。
 


### PR DESCRIPTION
## 目的（推奨）

Dependabot PR #535（mapbox-gl 3.10.0 → 3.27.0）が Frontend Build の型エラーで失敗している。Dependabot PR では依存の追加・削除ができないため、本 PR で更新と型解決をまとめて行い、#535 を supersede する（Refs #535。close はマージ後に行う）。

## 変更内容（推奨）

- `mapbox-gl` を `^3.10.0` → `^3.27.0` へ更新
- `@types/mapbox-gl` を削除（3.5.0 は deprecated stub。mapbox-gl 3 系は `dist/mapbox-gl.d.ts` を同梱）
- `@types/geojson@^7946.0.16` を devDependencies に追加
  - 旧 `@types/mapbox-gl@3.4.1` が推移的に供給していた `geojson` モジュール / ambient `GeoJSON` namespace の供給元。stub 化で供給が途切れ、`mapLayers.ts` / `MapContainer.tsx` の TS2307 と、mapbox-gl 同梱 d.ts の `GeoJSON.Feature` 未解決による `mapUtils.ts` の TS2339 が発生していた（ローカルで再現・解消を実測）
- `docs/operations/dependency-management.md` の「現行 Frontend Contract」に mapbox-gl / @types/geojson の行を追加
- アプリケーションコードの変更なし（型は追加依存だけで解決）

## 影響範囲（推奨）

- **対象**: `client/`（package.json / package-lock.json）、`docs/operations/dependency-management.md`
- **非対象**: root の依存・アプリケーションコード・terraform・workflows

## PRラベル（必須）

- **type**: `type:chore`
- **area**: `area:frontend`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

ローカル実測（すべて成功）:

- client: clean `npm ci` → `npx tsc --noEmit` / `npm run build` / `npm test`（5 tests）/ `npm audit` 0件
- ランタイム検証: Docker `postgres:16-alpine` + NestJS backend（`synchronize`）+ `vite preview`（production build）を Playwright 実ブラウザで確認
  - Mapbox 3D 地図が描画され、Roma / Carthage ラベルとハンニバルルートのポイント列（Narbonne / Saguntum / Ebro Crossing / Col de la Traversette / Libyssa 等）を目視確認
  - コンソールに `Capital Cities Data` / `Hannibal Route Data` / `Point Route Data` / `Map layers added successfully.` を確認。エラーは favicon 404 のみ（既知、#567 時と同一）

## ロールバック *条件付き*

軽運用。問題時は本 PR を revert して `npm ci` で復元（依存とdocsのみでコード変更なし）。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

1. `docker run postgres:16-alpine`（port 55432）
2. root `npm run build` → `DATABASE_URL=... node dist/main`（NestJS 起動、GraphQL 応答確認）
3. client `VITE_GRAPHQL_ENDPOINT=http://localhost:3000/graphql npm run build` → `npx vite preview --port 5173`
4. Playwright で `http://localhost:5173/` を開き、地図描画とコンソールログを確認

</details>

## メモ（レビューポイント）

- `@types/mapbox-gl` は DefinitelyTyped 側が「mapbox-gl provides its own type definitions, so you do not need this installed」と明示する stub のため、更新でなく削除を選択
- Refs #535（本 PR マージ後に supersede close する）


Closes #572
