### PR TITLE
refactor(client): MapContainerの未使用progress stateを削除する

### DIFF
--- a/client/src/components/MapContainer.tsx
+++ b/client/src/components/MapContainer.tsx
@@ -77,7 +77,6 @@ const GET_MAP_DATA = gql`
 const MapContainer: React.FC = () => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
-  const [progress, setProgress] = useState(0);
   const [isMapboxLoading, setIsMapboxLoading] = useState(true);
   const { loading, error, data } = useQuery<GetMapDataQuery>(GET_MAP_DATA);
 


### PR DESCRIPTION
## 目的（推奨）

`client/src/components/MapContainer.tsx:80` の `const [progress, setProgress] = useState(0);` はどこからも参照されていない dead code のため削除する。調査の結果、初回コミット（`1824721`、2025-04-10）から一度も使用実績がなく、進捗表示 UI・スタイル・テスト・docs 上の実装意図の記述も存在しないことを確認した（詳細は Issue #574 の調査記録）。

## 変更内容（推奨）

- `MapContainer.tsx` から未使用の `progress` state 宣言 1 行を削除
- 隣の `isMapboxLoading`（mapbox-gl 動的インポート中フラグとして使用中）は対象外

## 影響範囲（推奨）

- **対象**: `client/src/components/MapContainer.tsx`（1行削除）
- **非対象**: 依存関係・他コンポーネント・root・terraform・workflows。Issue #572 / PR #573（mapbox-gl 更新）とは無関係のリファクタのため PR を分離

## PRラベル（必須）

- **type**: `type:refactor`
- **area**: `area:frontend`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

ローカル実測（すべて成功）:

- client: `npx tsc --noEmit` / `npm run build` / `npm test`（5 tests）
- production build（`vite preview`）を Playwright 実ブラウザで開き、Mapbox 3D 地図・Roma / Carthage ラベル・ルートポイント列の描画と `Map layers added successfully.` ログに退行がないことを確認（エラーは favicon 404 のみ、既知）

## ロールバック *条件付き*

軽運用。問題時は本 PR を revert（1行の宣言復元のみ）。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

Docker `postgres:16-alpine` + NestJS backend + `vite preview`（production build）+ Playwright での地図描画確認。PR #573 と同一手順。

</details>

## メモ（レビューポイント）

- `git log -S` の全履歴走査でも当該行以外の `progress` / `setProgress` 参照コミットなし（ヒットした `441463c` はコミット済み dist バンドル削除のみ）。ローカル state はレキシカルスコープ外から参照できないため、grep + 履歴走査で未使用と断定した


Closes #574
