### PR TITLE
docs: run-local-map スキルの停止手順を実測済みの非対話手順に揃える

### DIFF
--- a/.claude/skills/run-local-map/SKILL.md
+++ b/.claude/skills/run-local-map/SKILL.md
@@ -88,17 +88,37 @@ cd client && npm ci && npm run dev
 4. `client/.env.local` を削除する
 5. 自動生成された `src/graphql/graphql.schema.ts` を revert する
 
-前景で起動している場合は、それぞれの端末で `Ctrl+C` を押す（1 → 2 の順）。
-そのうえで、listener が本当に消えたかを確認してから 3 以降へ進む。
+#### 1-2. vite dev サーバと NestJS バックエンドを停止する
+
+このスキルの主な利用者は AI エージェントであり、プロセスはバックグラウンド（非対話）で起動されるため、`Ctrl+C` を送れない前提で手順を組む。
+listener を握っている PID を `ss -ltnp` から特定して停止する。2026-08-10 に実測で動作確認済み。
 
 ```bash
-# 1-2. vite dev サーバ → NestJS バックエンドの順に停止し、listener を確認する
-ss -ltnp | grep -E ":5173|:3000"
+# listener を握っている PID を特定して停止する（vite → backend の順）
+for port in 5173 3000; do
+  pids=$(ss -ltnp 2>/dev/null | grep ":$port " | grep -oP 'pid=\K[0-9]+' | sort -u)
+  for pid in $pids; do kill $pid 2>/dev/null; done
+done
+sleep 3
+# 残っていれば SIGKILL
+for port in 5173 3000; do
+  pids=$(ss -ltnp 2>/dev/null | grep ":$port " | grep -oP 'pid=\K[0-9]+' | sort -u)
+  for pid in $pids; do kill -9 $pid 2>/dev/null; done
+done
+ss -ltn 2>/dev/null | grep -E ":3000|:5173" || echo "listener なし"
+```
 
-# 残っていた場合は、上で表示された PID を個別に停止する
-# kill <PID>
+- ポートの並び順 `5173 3000` が vite → バックエンドの停止順序を担保している。依存する側から先に落とすこと
+- `npx nest start` はラッパー経由で起動するため、`npm exec` / `nest start` のプロセスを kill しても**実際にポートを握っている子プロセスが生き残る**（実測）。プロセス名ではなく `ss -ltnp` からポートを握っている実プロセスの PID を拾う方式が確実
+- 最後の `ss -ltn` で listener が消えたことを必ず確認する。`listener なし` と出れば停止完了。プロセス一覧が空になっただけでは不十分
 
-# 3-5. 依存される側を片付ける
+前景で起動した端末が手元にある場合は、その端末で `Ctrl+C` を押しても止められる（1 → 2 の順）。ただしこの経路は未検証であり、いずれにせよ上の `ss -ltn` による listener 確認は行う。
+
+#### 3-5. 依存される側を片付ける
+
+listener が消えたことを確認してから実行する。
+
+```bash
 docker rm -f hannibal-pg-local
 rm -f client/.env.local
 git checkout -- src/graphql/graphql.schema.ts
@@ -106,19 +126,6 @@ git checkout -- src/graphql/graphql.schema.ts
 
 順序を守る理由: 依存される側（Postgres コンテナ・`client/.env.local`）を先に消し、依存する側（バックエンド・vite dev サーバ）を起動したまま放置すると、
 バックエンドが DB を失った状態で `/health` だけ 200 を返す紛らわしい状態になる（実測）。
-
-#### プロセス停止時の注意（実測）
-
-`npx nest start` はラッパー経由で起動するため、`npm exec` / `nest start` のプロセスを kill しても**実際にポートを握っている子プロセスが生き残る**。
-実測では、`ss -ltnp | grep :3000` で判明した別 PID を個別に kill する必要があった。
-
-停止後は listener が消えたことを必ず確認する。プロセス一覧が空になっただけでは不十分。
-
-```bash
-ss -ltn | grep -E ":3000|:5173"
-```
-
-何も出力されなければ停止完了。
 
 ## 落とし穴
 


### PR DESCRIPTION
## 目的（推奨）

`.claude/skills/run-local-map/SKILL.md` 手順6 の停止方法が `Ctrl+C` 前提で書かれていたが、この記述は一度も実行・検証されていない（`git log -S "Ctrl+C"` の初出は 5a5227d の 1 コミットのみ、SKILL.md 内で唯一の未検証記述）。
このスキルの主な利用者は Claude Code 自身であり `run_in_background` で起動するため、`Ctrl+C` を押せる状況が発生しない。実測済みの非対話停止手順を主手順に据える。

## 変更内容（推奨）

- 手順6 を `1-2. vite dev サーバと NestJS バックエンドを停止する` / `3-5. 依存される側を片付ける` の 2 小節に整理
- 停止の主手順を、`ss -ltnp` から listener を握る PID を特定して kill するワンライナー（2026-08-10 実測）に変更。ポートの並び順 `5173 3000` が vite → backend の停止順序を担保する
- 旧「プロセス停止時の注意（実測）」の内容（`npx nest start` がラッパー経由で子プロセスが生き残る点、listener 確認が必須な点）を主手順の注記に統合し、重複を解消
- `Ctrl+C` は前景起動時の代替手段として 1 行に縮小し、未検証である旨を明記

## 影響範囲（推奨）

- **対象**: `.claude/skills/run-local-map/SKILL.md`（ドキュメントのみ、27 行追加 / 20 行削除、最終 180 行）
- **非対象**: アプリケーションコード、Terraform、CI workflow、AWS リソース

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

Doc-only のため No-op（適用外）。
`npm run lint:md` を実行し、本ファイルに対する指摘が 0 件であることを確認済み（既存の `docs/worklogs/codex/**` の指摘は本 PR 前から存在する baseline で、差分なし）。
追記したワンライナー自体は 2026-08-10 に WSL 上で実行して動作確認済み。本 PR では文書変更のみで、ローカルサーバ・コンテナの起動は行っていない。

## ロールバック *条件付き*

軽運用 PR（`.claude/skills/**` は厳密運用の path 判定 `^(\.github/workflows/|scripts/github/|terraform/)` に該当しない）のため、実質的な記載は不要。
必要なら本 PR を revert すれば元の記述に戻る。

## リリース連携（推奨）

- **リリースノート**: 不要

## メモ（レビューポイント）

- `Ctrl+C` の記述を削除せず「未検証の代替手段」として残した判断が妥当か
- ワンライナーの SIGTERM → `sleep 3` → SIGKILL の段階構成


Closes #587
