### PR TITLE
docs: terraform-docs の生成結果を宣言バージョン 0.24.0 に揃える

### DIFF
--- a/terraform/foundation/README.md
+++ b/terraform/foundation/README.md
@@ -6,14 +6,14 @@ IAM / OIDC / CloudTrail / Athena / Budgets など、環境の土台になる恒�
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.8.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
 
 ## Modules
@@ -23,7 +23,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_athena_database.hannibal_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_database) | resource |
 | [aws_athena_named_query.analyze_cicd_errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_named_query) | resource |
 | [aws_athena_named_query.analyze_cicd_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_named_query) | resource |
@@ -85,13 +85,13 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_alert_email"></a> [alert\_email](#input\_alert\_email) | Email address for cost alerts | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_budget_names"></a> [budget\_names](#output\_budget\_names) | Monthly cost budget name |
 | <a name="output_pr_plan_role_arn"></a> [pr\_plan\_role\_arn](#output\_pr\_plan\_role\_arn) | ARN of HannibalPRPlanRole-Dev for use in PR terraform plan workflow (#122) |
 <!-- END_TF_DOCS -->

--- a/terraform/observability/README.md
+++ b/terraform/observability/README.md
@@ -4,40 +4,40 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.8.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_fis"></a> [fis](#module\_fis) | ../modules/fis | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [terraform_remote_state.service](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g. dev, staging, prod) | `string` | `"dev"` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for resource naming | `string` | `"nestjs-hannibal-3"` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_fis_experiment_template_id"></a> [fis\_experiment\_template\_id](#output\_fis\_experiment\_template\_id) | AWS FIS experiment template ID for the Game Day ECS task stop exercise (Issue #447, moved from terraform/service in Issue #458) |
 <!-- END_TF_DOCS -->

--- a/terraform/service/README.md
+++ b/terraform/service/README.md
@@ -6,7 +6,7 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.7 |
@@ -14,14 +14,14 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_codedeploy"></a> [codedeploy](#module\_codedeploy) | ../modules/codedeploy | n/a |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | ../modules/ecs | n/a |
 | <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | ../modules/load-balancer | n/a |
@@ -31,7 +31,7 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_password.alb_origin_verify_header](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [terraform_remote_state.database](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.network](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -39,7 +39,7 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_alb_certificate_arn"></a> [alb\_certificate\_arn](#input\_alb\_certificate\_arn) | ACM certificate ARN for HTTPS listener | `string` | n/a | yes |
 | <a name="input_alb_origin_secret_rotation_version"></a> [alb\_origin\_secret\_rotation\_version](#input\_alb\_origin\_secret\_rotation\_version) | Version key for rotating the ALB origin verify header secret | `string` | `"v1"` | no |
 | <a name="input_alert_email"></a> [alert\_email](#input\_alert\_email) | Email address for CloudWatch alarm notifications | `string` | `"gatsbykenji@gmail.com"` | no |
@@ -64,7 +64,7 @@ ECS、ALB、CodeDeploy、monitoring など、アプリケーション実行基�
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | ALB DNS name |
 | <a name="output_alb_origin_verify_header_value"></a> [alb\_origin\_verify\_header\_value](#output\_alb\_origin\_verify\_header\_value) | ALB origin verify header value for CloudFront |
 | <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | ALB hosted zone ID |


### PR DESCRIPTION
## 目的

`.mise.toml` は `terraform-docs = "0.24.0"` を宣言しているが、コミット済みの各 README は旧バージョン 0.20.0 で生成されたものだった。放置すると、次に誰かが `terraform/` 配下を触ってコミットした際に、その変更とは無関係な README 差分が自動で混入し、レビューのノイズになる。先に宣言バージョンで再生成して差分を解消する。

## 変更内容

- terraform-docs **v0.24.0** で `terraform/` 配下の root module README を再生成した（`pre-commit run terraform_docs --all-files`）
- 差分が出たのは以下の 3 ファイル（3 files changed, 17 insertions(+), 17 deletions(-)）
  - `terraform/foundation/README.md`
  - `terraform/observability/README.md`
  - `terraform/service/README.md`
- `terraform/network` / `terraform/database` / `terraform/cdn` は差分なし（0.24.0 の出力と一致していた）

## 影響範囲

- **対象**: `terraform/{foundation,observability,service}/README.md` の `<!-- BEGIN_TF_DOCS -->` ブロック内、マークダウン表の区切り行の書式のみ（`|------|---------|` → `| ---- | ------- |`）
- **非対象**: `.tf` ファイル、Terraform 構成、AWS リソース、CI workflow、`.mise.toml`、`.terraform-docs.yml`

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:infra`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 使用したツールバージョン

```console
$ terraform-docs --version
terraform-docs version v0.24.0 9d44551 linux/amd64
```

`.mise.toml` の宣言（`terraform-docs = "0.24.0"`）どおりのバイナリが mise shims 経由で解決されていることを確認したうえで実行した。

## 可観測性/検証 *条件付き*

生成ドキュメントのみの変更のため、ランタイムの可観測性への影響は **No-op（適用外）**。ドキュメント生成の正しさは以下で検証した。

1. **差分が書式のみであることの確認**（受け入れ条件3）
   - 変更された 17 行はすべてマークダウン表の区切り行であり、内容行（Requirements / Providers / Modules / Resources / Inputs / Outputs の各項目）は 1 行も増減していない
   - 区切り行を除外して再生成前後のファイルを機械的に比較したところ、3 ファイルとも完全一致することを確認した

     ```bash
     for f in terraform/foundation/README.md terraform/observability/README.md terraform/service/README.md; do
       diff <(git show HEAD:"$f" | grep -vE '^\|[-: |]+\|$') <(grep -vE '^\|[-: |]+\|$' "$f")
     done
     # => 3 ファイルとも差分なし
     ```

   - 変数名・型・デフォルト値・説明文・リソース名・アンカーリンクに変化がないことを目視でも確認した
2. **冪等性の確認**（受け入れ条件2）
   - 再生成後にもう一度 `pre-commit run terraform_docs --all-files` を実行し、`Passed` になることを確認した（追加の書き換えが発生しない）

## ロールバック *条件付き*

厳密運用PR（`terraform/**` 配下の変更）のため記載する。

- **手順**: このPRのsquash commitを `git revert <sha>` して main に戻すだけでよい。README の表の区切り行が 0.20.0 時代の書式に戻る。
- **前提と影響**: 変更は terraform-docs の生成物である README のみで、`.tf` ファイル・Terraform 構成・state・AWS リソースには一切触れていない。したがって revert に際して `terraform apply` / `destroy` / `state` 操作は不要であり、稼働中のリソースやデプロイ経路への影響もない。
- **切り戻し後の注意**: revert すると再びローカルの terraform-docs 0.24.0 と README の書式が不一致になるため、次に `terraform/` 配下を変更した開発者のコミット時に `terraform_docs` hook が同じ差分を再度発生させる（本PR前の状態に戻るだけで、新たな不具合は生じない）。
- **判断基準**: 本PRは生成物の書式変更のみで挙動を持たないため、ロールバックが必要になるシナリオは実質的に想定されない。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```console
$ terraform-docs --version
terraform-docs version v0.24.0 9d44551 linux/amd64

# 1回目: 差分が出るため Failed（フックがファイルを書き換える想定どおりの挙動）
$ pre-commit run terraform_docs --all-files
Terraform docs...........................................................Failed
- hook id: terraform_docs
- files were modified by this hook

$ git diff --stat
 terraform/foundation/README.md    | 10 +++++-----
 terraform/observability/README.md | 12 ++++++------
 terraform/service/README.md       | 12 ++++++------
 3 files changed, 17 insertions(+), 17 deletions(-)

# 2回目: 追加の書き換えが発生せず Passed（冪等性の確認）
$ pre-commit run terraform_docs --all-files
Terraform docs...........................................................Passed
```

`terraform init` / `plan` / `apply` / `destroy` / `state` は一切実行していない（AWS 認証不要の変更）。

</details>

## メモ（レビューポイント）

- 変更行がすべてマークダウン表の区切り行に限られており、Inputs / Outputs / Resources / Modules の項目に欠落や追加がないこと
- 生成に使ったバージョンが `.mise.toml` の宣言（0.24.0）と一致していること
- ADR-0023 のとおり、terraform-docs は CI gate ではなく pre-commit 運用のままであり、本PRでもその方針は変更していない


Closes #589
