### PR TITLE
ci: Terraform を 1.14.8 に統一し .mise.toml と CI pin の整合性検査を追加する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 - **Frontend**: React 19 + TypeScript 5.8 + Vite + Mapbox GL JS + Apollo Client
 - **Backend**: Node.js 24 + NestJS 11 + Apollo Server 5 + TypeScript 5.2 + GraphQL (Schema First) + TypeORM
 - **Database**: PostgreSQL 15 (RDS)
-- **Infrastructure**: Terraform 1.12.1 + AWS (ECS Fargate / ALB / CloudFront / Route53)
+- **Infrastructure**: Terraform 1.14.8 + AWS (ECS Fargate / ALB / CloudFront / Route53)
 - **CI/CD**: GitHub Actions (Blue/Green & Canary Deployment)
 
 ### アーキテクチャパターン

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy NestJS Hannibal
 
 env:
   PROJECT_NAME: "nestjs-hannibal-3"
-  TERRAFORM_VERSION: "1.12.1"
+  TERRAFORM_VERSION: "1.14.8"
   NODE_VERSION: "24"
 
 on:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -2,7 +2,7 @@ name: Destroy AWS Infrastructure (Reliable)
 
 env:
   PROJECT_NAME: "nestjs-hannibal-3"
-  TERRAFORM_VERSION: "1.12.1"
+  TERRAFORM_VERSION: "1.14.8"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TERRAFORM_VERSION: "1.12.1"
+  TERRAFORM_VERSION: "1.14.8"
   NODE_VERSION: "24"
   POSTGRES_IMAGE: "postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb"
   CURL_IMAGE: "curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13"
@@ -244,7 +244,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.12.1
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
       - name: Terraform Format Check

--- a/.github/workflows/toolchain-version-check.yml
+++ b/.github/workflows/toolchain-version-check.yml
@@ -1,0 +1,43 @@
+# Toolchain Version Check
+# 目的: ローカル正本（.mise.toml）が宣言する Terraform バージョンと、CI workflow に
+#       直書きされた pin が一致することを機械検査する（設計判断は ADR 0031 / idp-golden-path ADR-0014）。
+# 実体は kmryst/idp-golden-path の reusable workflow（ADR 0008 相当の配布方式）。
+# このファイルはトリガー・permissions・concurrency のみを持つ薄い caller workflow
+#
+# 検査対象は `.mise.toml` の `[tools] terraform` と、`.github/workflows/*.yml` 中の
+# `TERRAFORM_VERSION:` / `terraform_version:` の**リテラル値**。`${{ env.TERRAFORM_VERSION }}`
+# のような式による間接参照は「実体ではなく参照」なので pin とみなされない。
+# 本リポジトリでは pr-check.yml / deploy.yml / destroy.yml の env 定義 3 箇所が検査対象になる。
+#
+# input（mise-config-path / workflow-paths）は既定値で足りるため渡さない。
+# `.mise.toml` はリポジトリルートにあり、Terraform pin も `.github/workflows/*.yml` にしかない。
+#
+# Dependabot PR も免除しない。人間向けの記述規約を検査する Commitlint / PR Policy Check と違い、
+# これは機械的な整合性検査であり、免除すると検知の穴になる（Markdown Lint / CodeQL と同じ扱い）。
+
+name: Toolchain Version Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # idp-golden-path 側の reusable workflow 自身も同名パターンの concurrency group
+  # （toolchain-version-check-<PR番号>）を持つため、caller 側と同一名にすると
+  # 「top level workflow と呼び出し先の間でデッドロック」として GitHub にキャンセルされる
+  # （ticket-c2c-platform#294 / idp-golden-path#106参照）。
+  # caller 側は `-caller` を付けて callee の group と衝突しないようにする。
+  group: toolchain-version-check-caller-${{ github.event.pull_request.number }}
+  # 実行中 run のキャンセルは CANCELLED check run を commit に残し、
+  # required status checks の判定に混入して PR を恒久的にブロックする（Issue #438）。
+  cancel-in-progress: false
+
+jobs:
+  # caller job には name を付けない。job id（toolchain-version-check）にフォールバックさせることで、
+  # callee側 job 名（Toolchain Version Check）との完全な文字列重複を避ける（idp-golden-path#106参照）。
+  toolchain-version-check:
+    uses: kmryst/idp-golden-path/.github/workflows/toolchain-version-check.yml@v1

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-terraform = "1.12.1"
+terraform = "1.14.8"
 node = "24.18.0"
 pre-commit = "4.5.1"
 "terraform-docs" = "0.24.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ PR 本文には `Closes #<issue番号>` / `Fixes #<issue番号>` / `Refs #<issue
 
 ### 実行してよい検証コマンド
 
+ローカルの Terraform バージョンは `.mise.toml`（`1.14.8`）が正本。`mise install` 済みであることを前提とし、CI の pin と一致していることは `Toolchain Version Check` が検査する（ADR 0031）。
+
 ```bash
 # フォーマットチェック（差分なしが正常）
 terraform fmt -check -recursive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ mise install
 pre-commit install
 ```
 
+`.mise.toml` はローカル実行環境のツールチェーンバージョンの正本です（ADR 0023）。CI は `.mise.toml` を読まず workflow 内で明示 pin しますが、pin の値は `.mise.toml` の宣言と一致させます（ADR 0031）。
+Terraform のバージョンを更新する場合は、`.mise.toml` と `.github/workflows/` の `pr-check.yml` / `deploy.yml` / `destroy.yml` の `env.TERRAFORM_VERSION` を同じ PR で変更してください。不一致は `Toolchain Version Check` が検出します。
+
 Terraform root module の README は `terraform_docs` pre-commit hook で更新します。
 Terraform root module を変更した場合は、コミット前に必要に応じて次を実行してください。
 
@@ -389,6 +392,9 @@ Issue 本文には専用の運用区分欄を追加せず、Issue 起票前プ�
 
 `Commitlint` は PR title・PR内コミットメッセージを検査する CI check です。
 required status check に含める場合は、workflow 追加後に GitHub の branch protection 設定も同期します。
+
+`Toolchain Version Check` は `.mise.toml` が宣言する Terraform バージョンと CI の pin が一致することを検査する CI check です。
+新しいガードレールのため required status check には含めていません（[ADR 0031](./docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md)）。
 
 ### terraform plan の扱い
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Issue / PR / Label / CI のガードレール整備後から、面接で深掘�
 
 | 領域 | 技術 |
 |---|---|
-| IaC | Terraform 1.12.1 |
+| IaC | Terraform 1.14.8 |
 | AWS | ECS Fargate、ALB、CloudFront、RDS PostgreSQL、S3、Route53、CloudTrail、Athena、CloudWatch |
 | CI/CD | GitHub Actions、CodeDeploy Blue/Green、Canary deployment |
 | Identity / Security | IAM、OIDC、Permission Boundary、TFLint、Trivy、Gitleaks、CodeQL |

--- a/docs/adr/0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md
+++ b/docs/adr/0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md
@@ -117,9 +117,20 @@ pre-commit で root module README を生成できる状態を先に作り、CI r
 - CI では terraform-docs drift をまだ検出しない
 - version 更新 PR では `.mise.toml` と `.github/workflows/*.yml` の pin の関係を review する必要がある
 
+### 追記（2026-08-10）: 短所として挙げた drift が現実化した
+
+本 ADR は採択案の短所として「`.mise.toml` と workflow pin の間に version drift が起きる可能性が残る」ことを挙げ、「version 更新時に両方を一緒に確認する運用で扱う」としていた。2026-08-10 の実測で、このリスクが現実化していたことが判明した。
+
+`.mise.toml` は Terraform `1.12.1` を宣言していたが mise 自体が導入されておらず宣言に強制力がなく、実際には apt でインストールされた `1.14.8` が使われていた。その結果 `terraform/foundation` の state（実リソース 57 件）が `1.14.8` に上がり、`1.12.1` を pin する CI からも、宣言どおりの CLI を使うローカルからも操作できない層が生まれた。
+
+`.mise.toml` をローカル正本とし CI は明示 pin とする**構造そのものは維持する**（[ADR 0031](./0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md) が案 D として二重管理の廃止を再検討したうえで、同じ理由で見送っている）。欠けていたのは検知手段であり、宣言と pin の一致は ADR 0031 で CI の機械検査に置き換えた。本 ADR の「運用で気を付ける」という扱いは、ADR 0031 の検査に取って代わられている。
+
+Terraform のバージョン値自体も ADR 0031 で `1.14.8` に更新されている。本 ADR 本文中の記述は採択当時のものとして残す。
+
 ## 関連
 
 - [Issue #427](https://github.com/kmryst/terraform-hannibal/issues/427)
+- [ADR 0031. Terraform を 1.14.8 に統一し、ローカル正本と CI pin の整合性を CI で検査する](./0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md)
 - [Quality Gates](../operations/quality-gates.md)
 - [Terraform Modules Architecture](../architecture/terraform-modules.md)
 - [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md
+++ b/docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md
@@ -1,0 +1,119 @@
+# 0031. Terraform を 1.14.8 に統一し、ローカル正本と CI pin の整合性を CI で検査する
+
+## ステータス
+
+Accepted
+
+## 日付
+
+2026-08-10
+
+## 決定内容
+
+本リポジトリの Terraform CLI バージョンを **1.14.8** に統一する。統一先の値と検査方式は 3 リポジトリ共通標準である `kmryst/idp-golden-path` の ADR 0014 に従い、本リポジトリはその消費側として適用する。
+
+- `.mise.toml` の `[tools] terraform` を `1.14.8` にする。ローカル実行環境のツールチェーンバージョンの正本は引き続き `.mise.toml`（ADR 0023 の決定を維持）
+- CI（GitHub Actions）は `.mise.toml` を読まず workflow 内で明示 pin する（ADR 0023 の決定を維持）。pin の値は `.mise.toml` の宣言と一致させる
+- Terraform バージョンの更新点を **`env.TERRAFORM_VERSION` の 1 箇所に集約**する。`pr-check.yml` の `hashicorp/setup-terraform` に直書きされていた `terraform_version: 1.12.1` は `${{ env.TERRAFORM_VERSION }}` の参照に変更する。`deploy.yml` / `destroy.yml` は既に env 参照であり、これで 3 workflow の形が揃う
+- 宣言と pin の一致は人間の注意力に任せず、`kmryst/idp-golden-path/.github/workflows/toolchain-version-check.yml@v1` を消費する caller workflow で **PR ごとに機械検査**する
+- 新規ガードレールのため、branch protection の required status checks には即座には追加しない（段階的 required 化の方針は [ADR 0013](./0013-promote-quality-checks-to-required-gradually.md) に従う）
+
+root module の `required_version` は `>= 1.11.0` のまま変更しない。1.14 系だけが必要な機能を使っていないため、宣言上の機能下限を実行環境の pin に合わせて引き上げる理由がない（[docs/terraform-environments.md](../terraform-environments.md)）。
+
+## 背景
+
+### drift が現実化していた
+
+[ADR 0023](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md) は「`.mise.toml` をローカル正本とし、CI/CD workflow は明示 pin を維持する」を採択し、その短所として「`.mise.toml` と workflow pin の間に version drift が起きる可能性が残る」ことを明記していた。2026-08-10 の実測で、**このリスクが既に現実化していた**ことが判明した。
+
+- `.mise.toml` は Terraform `1.12.1` を宣言していたが、**mise 自体が導入されておらず宣言に強制力がなかった**
+- 実際のローカル実行では apt でインストールされた Terraform `1.14.8` が使われていた
+- その結果 `terraform/foundation` の state（実リソース 57 件）が `1.14.8` に上がっていた
+
+ADR 0023 が想定していた「version 更新時に `.mise.toml` と workflow pin を一緒に確認する運用」は、宣言そのものが実行環境に効いていない状況では機能しない。drift の検知手段がなかったため、誰も気付けなかった。
+
+### 更新経路が失われていた層
+
+Terraform の state は前方互換がなく、記録された `terraform_version` より古い CLI での操作を拒否する。`terraform/foundation` は原則として人間が手動 apply する層であり（[CLAUDE.md](../../CLAUDE.md)）、CI の deploy/destroy 対象ではない。
+
+- `foundation` の state: `1.14.8`
+- CI の pin（`pr-check.yml` / `deploy.yml` / `destroy.yml`）: `1.12.1`
+- `.mise.toml` の宣言: `1.12.1`
+
+つまり、宣言どおりに `1.12.1` を使うと `foundation` を操作できない。実リソース 57 件を抱えたまま、正規の手順からは更新できない層が成立していた。
+
+一方、CI が触る 5 層（network / database / service / cdn / observability）は state の `terraform_version` が `1.12.1` で、いずれもリソース 0 件（destroy 済み）だった。これらは次回 apply 時に `1.14.8` へ上がるだけで、実リソースへの影響はない。
+
+### 3 リポジトリ横断の分裂
+
+同じ実測で `idp-golden-path` / `ticket-c2c-platform` を含む 3 リポジトリの state 13 件を調べたところ、実リソースを持つ state は既に `1.14.8` に上がっており、`1.12.1` はリソース 0 件の層にしか残っていなかった。層ごとにバージョンが割れているのは設計判断ではなく、CI 経由で実行したか手動で実行したかによってたまたま使われた CLI が違っただけの事故である。
+
+この分裂の解消方針を 3 リポジトリ標準として定めたのが `idp-golden-path` の ADR 0014 であり、本 ADR はその消費側としての適用判断を記録する。
+
+## 検討した選択肢
+
+### 案 A: 1.12.1 に揃える（`.mise.toml` の宣言を実効値とする）
+
+CI pin を一切変えずに済み、これまでの CI 実行実績（1.12.1）をそのまま踏襲できる。
+
+しかし `foundation` の state が既に `1.14.8` で記録されており、前方非互換のため `1.12.1` では操作できない。実行するには state ファイル内の `terraform_version` を手で書き換える必要があり、実リソース 57 件を抱えた state に対する手動編集は復旧不能な破壊のリスクを伴う。「バージョンを揃える」という可逆な作業のために不可逆な破壊リスクを取ることになるため却下した。
+
+### 案 B: 層ごと・リポジトリごとに異なるバージョンを許容する
+
+現状をそのまま追認するため移行コストはゼロになる。
+
+しかし `foundation` の更新経路が無いという実害が解消しない。さらに、どのバージョンが「意図された値」なのか定義されないままなので、drift の検査基準そのものが作れない。事故を仕様に格上げするだけであり却下した。
+
+### 案 C: 1.14.8 に統一するが、検査は入れず運用注意に留める
+
+ADR 0023 と同じ「更新時に両方を見る」運用を継続する案。変更範囲が最小で、CI の job も増えない。
+
+しかし今回の事故は、まさにその運用が機能しないことを実証している。値だけを揃えても、次に片方だけを更新した時点で同じ状態に戻る。今回の本質はバージョンの値ではなく**宣言と実効値の乖離を誰も検知できなかったこと**にあるため却下した。
+
+### 案 D: CI から `.mise.toml` を直接読み、二重管理そのものを廃止する
+
+version source を完全に一本化でき、drift が原理的に発生しなくなる。
+
+しかし CI に mise のインストール手順を持ち込むと、`hashicorp/setup-terraform` / `actions/setup-node` のキャッシュと実行実績を捨てることになる。ADR 0023 が同じ理由でこの案を見送っており、今回それを覆すだけの新しい根拠はない。二重管理の唯一の欠点である drift を検査で潰せるなら、こちらの方が安価である。
+
+### 案 E（採択）: 1.14.8 に統一し、整合性を reusable workflow で機械検査する
+
+`.mise.toml` をローカル正本、CI pin をその写像とする ADR 0023 の構造を維持したまま、両者の一致を CI で検査する。検査ロジックは `idp-golden-path` から reusable workflow として配布されているものを `@v1` で消費し、本リポジトリには薄い caller のみを置く。
+
+## 採択理由
+
+- state の前方非互換という制約が選択肢を実質的に一つに絞っている。1.14.8 は「良いから選んだ」のではなく、**実リソースを持つ state が既にそこにいるから、そこしか行き場がない**（案 A の却下理由）
+- ADR 0023 の構造（ローカル正本 + CI 明示 pin）自体は誤っていなかった。欠けていたのは検知手段だけであり、構造を作り替える案 D より、短所を潰す案 E の方が変更範囲に対する効果が大きい
+- 案 C を採らないのは、ADR 0023 が既に「運用で気を付ける」を試して失敗しているため。同じ対策を再掲しても再発を防げない
+- 検査ロジックを本リポジトリに実装せず reusable workflow を消費するのは、3 リポジトリに同じロジックをコピーすると必ず乖離するため。CI ガードレールの共通化方針（[github-flow-guardrails.md](../operations/github-flow-guardrails.md)）と一致する
+- `pr-check.yml` の直書きを `${{ env.TERRAFORM_VERSION }}` に変えるのは、更新点を 1 箇所に集約するため。同一ファイル内に更新点が 2 つあると、片方だけ直す事故が起きる。検査器は式による間接参照を pin とみなさないため、この変更で検査対象は env 定義 3 箇所に絞られ、検査の意味も明確になる
+
+## 影響
+
+- `.mise.toml` の Terraform 宣言が `1.14.8` になる。`mise install` 済みの環境では `terraform` コマンドがそのまま 1.14.8 を解決する
+- `pr-check.yml` / `deploy.yml` / `destroy.yml` の `TERRAFORM_VERSION` が `1.14.8` になる。今後の Terraform バージョン更新は `.mise.toml` と各 workflow の `env` の計 4 箇所を同時に変更する（不一致は CI が検出する）
+- `pr-check.yml` の `setup-terraform` は `${{ env.TERRAFORM_VERSION }}` を参照するようになり、同一ファイル内の更新点が 1 つになる
+- PR ごとに `toolchain-version-check / Toolchain Version Check` の check run が作成される。Dependabot PR も免除しない
+- CI が触る 5 層（network / database / service / cdn / observability）の state は、次回 apply 時に `terraform_version` が `1.14.8` へ上がる。いずれも現時点でリソース 0 件のため実リソースへの影響はない
+- `foundation` 層は、ローカル CLI が 1.14.8 になることで **更新経路が回復する**。これが本変更の実質的な効果である
+- 一度 1.14.8 で apply した state は 1.12.1 の CLI で操作できなくなる。ロールバックはこの PR をマージし apply する前に限り無害である
+- 全 6 root module が Terraform 1.14.8 で `fmt -check -recursive` / `init -backend=false` / `validate` を通ることをローカルで実測確認した。`fmt -check` の結果は 1.12.1 と 1.14.8 で同一（どちらも差分なし）、deprecation warning は 0 件、`.terraform.lock.hcl` の変更も発生しなかった
+- 検査対象は Terraform のみである。TFLint は `.mise.toml`（`0.62.1`）と `pr-check.yml`（`v0.62.1`）が一致しているが検査されない。Node.js は `.mise.toml` が `24.18.0`、workflow が major のみの `24` で粒度が異なるため、そもそも一致検査になじまない
+
+## 再検討条件
+
+- **Terraform の新しいメジャーバージョンが出た場合**（2.x など）。state 互換性・provider 互換性・setup アクションの対応状況を確認し、統一先を更新するか判断する
+- **1.14.8 に固有の不具合が判明した場合**。移行先は 1.14.x の patch 上位であり、ダウングレードではない（前方非互換の制約は変わらない）
+- **CI が mise を直接使う構成へ移行した場合**（案 D）。ローカル正本と CI pin の二重管理そのものが不要になり、本 ADR の検査も役目を終える
+- **`.mise.toml` 以外のツールチェーン宣言方式へ移行した場合**（`.tool-versions` / devcontainer / Nix など）。検査器のパーサを差し替える必要がある
+- **TFLint / Node.js も検査対象に加えたくなった場合**。reusable workflow 側の拡張として `idp-golden-path` で判断する
+
+## 関連
+
+- [Issue #591](https://github.com/kmryst/terraform-hannibal/issues/591)
+- [ADR 0013. 品質チェックを観察期間後に段階的 required 化する](./0013-promote-quality-checks-to-required-gradually.md)
+- [ADR 0023. ローカルツール管理に mise を採用し terraform-docs は pre-commit で運用する](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md) — 本 ADR は 0023 を supersede せず、0023 が短所として挙げていた version drift リスクに検知手段を追加する
+- kmryst/idp-golden-path ADR 0014（Terraform ツールチェーンのバージョンを 3 リポジトリで 1.14.8 に統一し、ローカル正本と CI pin の整合性を CI で検査する）— 統一先バージョンと検査契約の正本
+- [Terraform 環境分離設計](../terraform-environments.md)
+- [GitHub Flow Guardrails](../operations/github-flow-guardrails.md)
+- [Terraform Docs: State — version compatibility](https://developer.hashicorp.com/terraform/language/state)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ ADR はその正本を置き換えるものではなく、重要な設計判断�
 | [0028](./0028-fis-game-day-ecs-task-stop-experiment-design.md) | Accepted | AWS FISでECSタスク強制停止によるGame Day演習を自動化する |
 | [0029](./0029-separate-fis-observability-root-module-for-blast-radius.md) | Accepted | AWS FIS実験テンプレートを独立root module `terraform/observability` に分離する |
 | [0030](./0030-adopt-cloudwatch-synthetics-canary-for-user-journey-monitoring.md) | Accepted | ユーザージャーニーレベルの外形監視にCloudWatch Synthetics canaryを採用する |
+| [0031](./0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md) | Accepted | Terraform を 1.14.8 に統一し、ローカル正本と CI pin の整合性を CI で検査する |

--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -28,6 +28,9 @@ Terraform / AWS / SRE 実践としての固有判断はこのリポジトリに�
   - CodeQL: `security-scan.yml` 内にあった `sast-scan` job（週次のみ実行、PR非トリガー）は `codeql.yml`（PR/push ごとに実行）と重複するため削除し、一本化した
   - Dependency Audit: 本リポジトリは npm workspaces を使わず root（`package-lock.json`）と `client/`（`client/package-lock.json`）が独立した2つのnpmプロジェクトのため、`working-directory` を変えて2 job呼び出す
   - Markdown Lint: 前提の `lint:md` script・`.markdownlint-cli2.jsonc` が本リポジトリになかったため新規追加した。`.amazonq/rules/`・`.github/copilot-instructions.md`・`.cursor/rules/` は CLAUDE.md が明記する通り各ツール向け補助ルールで正本ではないため、lint 対象外とした
+- Toolchain Version Check を `idp-golden-path` の reusable workflow を `@v1` で消費する caller workflow として新規導入した（Issue #591）。`.mise.toml` が宣言する Terraform バージョンと、workflow に直書きされた `TERRAFORM_VERSION:` / `terraform_version:` のリテラル値が一致することを PR ごとに検査する。ADR 0023 が短所として挙げていた drift が現実化していた（`.mise.toml` は 1.12.1 を宣言していたが実際には 1.14.8 が使われ、`terraform/foundation` の state が 1.14.8 に上がっていた）ことへの対策で、設計判断は [ADR 0031](../adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md)。新しいガードレールのため required status checks には追加しない。
+  - 検査器は式による間接参照（`${{ env.TERRAFORM_VERSION }}` など）を pin とみなさないため、`pr-check.yml` の `setup-terraform` への直書きを env 参照に変更し、検査対象を各 workflow の `env` 定義 3 箇所に集約した。Terraform バージョンの更新点は `.mise.toml` と `env` の計 4 箇所になる
+  - Dependabot PR も免除しない。Commitlint / PR Policy Check の免除は人間向けの記述規約を bot に要求しないためのものだが、これは機械的な整合性検査であり免除すると検知の穴になる（Markdown Lint / CodeQL と同じ扱い）
 - helper scripts は共通化途上であり、`idp-golden-path` の `scripts/github/lib/common.sh` 形式には揃っていない。
 - Terraform plan / apply / destroy、TFLint、Trivy Config Scan などの Terraform / AWS 固有 workflow は、このリポジトリ固有の責務として残す。
 
@@ -59,6 +62,7 @@ Terraform / AWS / SRE 実践としての固有判断はこのリポジトリに�
 - PR title と PR 内コミットメッセージは `Commitlint` job で Conventional Commits 形式を検査する
 - `TFLint` と `Gitleaks Secret Scan` は #228 で required status checks に追加した
 - `Trivy Config Scan` は HIGH / CRITICAL finding を review signal として表示するが、#228 時点では blocking gate にしない
+- `Toolchain Version Check` は `.mise.toml` と CI の Terraform pin の一致を検査する review signal として追加し、#591 時点では required status checks に含めない
 - GitHub App `Amazon Q Developer` による自動コードレビューを review signal として利用する（詳細は「自動コードレビュー（Amazon Q Developer）」節）
 
 ### 軽運用 / 厳密運用

--- a/docs/terraform-environments.md
+++ b/docs/terraform-environments.md
@@ -12,7 +12,7 @@ Preview Environment は現時点では本格設計・実装せず、dev deploy/d
 
 - **バックエンド**: S3 バケット `nestjs-hannibal-3-terraform-state`
 - **State lock**: 全 6 root module で S3 lockfile（`use_lockfile = true`）を使用する
-- **Terraform CLI**: 全 6 root module の最低バージョンは `>= 1.11.0` とする
+- **Terraform CLI**: 全 6 root module の最低バージョンは `>= 1.11.0` とし、ローカル / CI の実行バージョンは `1.14.8` に統一する（ADR 0031）
 - **バケットは共有可**（同一バケット内で key 分離すれば競合しない）
 
 | root module | State キー | 内容 |
@@ -30,7 +30,11 @@ Preview Environment は現時点では本格設計・実装せず、dev deploy/d
 
 このプロジェクトは S3 backend の `use_lockfile = true` を state lock の正とする。Terraform v1.10.0 で S3 native state locking は導入されたが、v1.11.0 のリリースノートで generally available と明記され、DynamoDB 関連引数は新しい locking mechanism に置き換える方向で deprecated になった。そのため、宣言上の最低バージョンは「導入された 1.10」ではなく「GA になった 1.11」を下限にする。
 
-一方で、CI/CD workflow（`pr-check.yml` / `deploy.yml` / `destroy.yml`）は Terraform `1.12.1` を明示的に使用している。現時点の構成に Terraform 1.12 系だけが必要な機能はないため、root module の `required_version` は実行環境の pin と同じ `>= 1.12.1` にはせず、構成が必要とする機能下限として `>= 1.11.0` を宣言する。workflow 側の `1.12.1` は、CI/CD 実行時の再現性を保つための pin として扱う。
+一方で、CI/CD workflow（`pr-check.yml` / `deploy.yml` / `destroy.yml`）は Terraform `1.14.8` を明示的に使用している。現時点の構成に Terraform 1.12 系以降だけが必要な機能はないため、root module の `required_version` は実行環境の pin と同じ `>= 1.14.8` にはせず、構成が必要とする機能下限として `>= 1.11.0` を宣言する。workflow 側の `1.14.8` は、CI/CD 実行時の再現性を保つための pin として扱う。
+
+実行環境の pin を `1.14.8` としているのは、性能や機能上の要求ではなく、`terraform/foundation` の state が既に `1.14.8` で記録されており、Terraform の state が前方互換を持たない（記録された `terraform_version` より古い CLI での操作を拒否する）ためである。3 リポジトリ共通の統一先としての判断は [ADR 0031](./adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md) を参照する。
+
+ローカル実行環境のバージョン正本は `.mise.toml`（ADR 0023）であり、workflow の pin はその写像である。両者の一致は `toolchain-version-check.yml`（idp-golden-path の reusable workflow を消費する caller）が PR ごとに機械検査する。Terraform バージョンを更新するときは、`.mise.toml` と `pr-check.yml` / `deploy.yml` / `destroy.yml` の `env.TERRAFORM_VERSION` を同時に変更する。
 
 参考:
 


### PR DESCRIPTION
## 目的

Terraform CLI のバージョンを 3 リポジトリ標準の **1.14.8** に統一し、ローカル正本（`.mise.toml`）と CI pin の一致を CI で機械検査できるようにする。

ADR 0023 が短所として挙げていた「`.mise.toml` と workflow pin の間の version drift」が現実化していた。`.mise.toml` は 1.12.1 を宣言していたが mise 自体が未導入で強制力がなく、実際には apt 版 1.14.8 が使われ、`terraform/foundation` の state（実リソース 57 件）が 1.14.8 に上がっていた。Terraform の state は前方互換がないため、1.12.1 を pin する CI からも宣言どおりの CLI を使うローカルからも foundation を操作できない状態が成立していた。

値を揃えるだけでは同じ事故が再発するため、宣言と pin の一致検査を同じ PR で導入する。

## 変更内容

**バージョン統一（4 箇所）**

- `.mise.toml`: `terraform = "1.12.1"` → `"1.14.8"`
- `.github/workflows/pr-check.yml` L16: `env.TERRAFORM_VERSION` → `"1.14.8"`
- `.github/workflows/deploy.yml` L5 / `destroy.yml` L5: `env.TERRAFORM_VERSION` → `"1.14.8"`
- `.github/workflows/pr-check.yml` L247: `setup-terraform` の `terraform_version: 1.12.1` 直書きを `${{ env.TERRAFORM_VERSION }}` の参照に変更（数値の書き換えではなく、更新点を env の 1 箇所に集約する変更。env を定義しているのに参照していない不整合の解消でもある）

**整合性チェックの追加**

- `.github/workflows/toolchain-version-check.yml` を新規追加。`kmryst/idp-golden-path/.github/workflows/toolchain-version-check.yml@v1` を消費する薄い caller。check run 名は `toolchain-version-check / Toolchain Version Check`
- input は既定値で足りるため渡さない（`.mise.toml` はリポジトリルート、Terraform pin は `.github/workflows/*.yml` のみ）
- `concurrency.group` は `toolchain-version-check-caller-<PR番号>`（callee と同名にするとデッドロック判定される）。caller job には `name:` を付けず job id にフォールバックさせる

**ADR**

- `docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md` を新規追加（Accepted）
- ADR 0023 に「短所として挙げた drift が現実化した」追記を追加。0023 は supersede しない（mise をローカル正本とし CI は明示 pin とする**構造そのものは維持**しており、欠けていたのは検知手段のみ。0031 は二重管理の廃止を案 D として再検討したうえで同じ理由で見送っている）
- `docs/adr/README.md` の一覧に 0031 を追加

**Docs**

- `docs/terraform-environments.md`: 1.12.1 pin の根拠を記述していた節を更新。`required_version >= 1.11.0` は据え置き（1.14 系だけが必要な機能は使っていない）とし、実行環境 pin を 1.14.8 とする理由（state の前方非互換）と、`.mise.toml` / workflow pin の関係・検査の存在を追記
- `docs/operations/github-flow-guardrails.md`: 未収束点と review signal 一覧に Toolchain Version Check を追記
- `CONTRIBUTING.md`: ローカル環境セットアップに更新手順（4 箇所を同じ PR で変更する）、CI チェック節に非 required の check として追記
- `CLAUDE.md`: Terraform 検証コマンド節にローカルバージョンの正本を明記
- `README.md` 技術スタック表 / `.github/copilot-instructions.md`: `Terraform 1.12.1` → `1.14.8`

## 影響範囲

- **対象**: Terraform CLI の実行バージョン（ローカル / CI）、PR チェックの構成、Terraform バージョン運用に関する docs
- **非対象**: root module の `required_version`（`>= 1.11.0` のまま）、AWS リソース、TFLint / Node.js / terraform-docs のバージョン、他リポジトリ

この PR は設定ファイルと docs の変更のみで、`terraform apply` を伴わない。

## PRラベル（必須）

- **type**: `type:infra`
- **area**: `area:ci-cd`, `area:infra`, `area:docs`
- **risk**: `risk:medium`
- **cost**: `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**リスク根拠**（Medium）: `.github/workflows/**` の変更であり deploy / destroy の実行環境バージョンを変える。ただし変更内容は Terraform CLI のバージョン pin と検査 workflow の追加に限られ、AWS リソースへの操作は含まない。

</details>

## 可観測性/検証 *条件付き*

ローカルで Terraform 1.14.8 による実測を行った（CI green だけを根拠にしない）。

| 検証 | 結果 |
|---|---|
| `terraform fmt -check -recursive`（1.14.8） | exit 0（差分なし） |
| `terraform fmt -check -recursive`（1.12.1、比較用） | exit 0（差分なし。両バージョンで結果が同一） |
| `init -backend=false` / `validate` × 全 6 root module | 全て exit 0（foundation / network / database / service / cdn / observability） |
| deprecation warning | 0 件 |
| `.terraform.lock.hcl` の md5 | 全 6 file 変更なし |
| `.mise.toml` 変更後の `terraform version` | `Terraform v1.14.8`（mise shim 経由で解決。`mise exec` 不要） |

`init` は全て `-backend=false` で実行し、リモート state には一切触れていない。`apply` / `destroy` / `state` は実行していない。

CI では `toolchain-version-check / Toolchain Version Check` が pass することを確認する（`.mise.toml` の 1.14.8 と env pin 3 箇所の一致を検査）。

## ロールバック *条件付き*

**この PR 単体のロールバック（apply 前）は無害である。** 変更は設定ファイルと docs のみで、`terraform apply` を伴わない。revert commit で `.mise.toml` と 3 workflow の pin を 1.12.1 に戻し、`toolchain-version-check.yml` を削除すれば元の状態に戻る（caller を残したまま pin だけ戻すと `.mise.toml` との不一致で CI が fail するため、両方を同時に戻す）。

**apply 後は前方非互換のため実質的に不可逆になる。** Terraform の state は記録された `terraform_version` より古い CLI での操作を拒否するため、1.14.8 で apply した state は 1.12.1 では読めなくなる。戻すには state ファイル内の `terraform_version` を手で書き換える必要があり、復旧不能な破壊のリスクを伴う。

ただし現時点で CI が触る 5 層（network / database / service / cdn / observability）は**全てリソース 0 件（destroy 済み）**であり、state には serial だけが存在する。次回 apply 時に state が 1.14.8 へ上がるが、実リソースへの影響はない。`terraform/foundation`（実リソース 57 件）の state は既に 1.14.8 であり、この PR はむしろその層の更新経路を回復させる。

したがって、ロールバックが必要になる現実的なケースは「1.14.8 に固有の不具合が判明した場合」だが、その移行先は 1.14.x の patch 上位であってダウングレードではない（ADR 0031「再検討条件」）。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```bash
mise exec terraform@1.14.8 -- terraform fmt -check -recursive   # exit 0
for dir in terraform/foundation terraform/network terraform/database terraform/service terraform/cdn terraform/observability; do
  mise exec terraform@1.14.8 -- terraform -chdir="$dir" init -backend=false
  mise exec terraform@1.14.8 -- terraform -chdir="$dir" validate
done   # 全て exit 0 / Success! The configuration is valid.

md5sum terraform/*/.terraform.lock.hcl   # 実行前後で不変
terraform version                        # Terraform v1.14.8
```

markdownlint（変更した md 8 file）: 0 issues。`npm run commitlint`: 0 problems。

</details>

## メモ（レビューポイント）

- `pr-check.yml` L247 を `${{ env.TERRAFORM_VERSION }}` に変えている点。検査器は `TERRAFORM_VERSION:` / `terraform_version:` の**リテラル値のみ**を pin とみなし、式による間接参照は pin と扱わない。この変更により検査対象は env 定義 3 箇所に絞られ、Terraform バージョンの更新点は `.mise.toml` + env 3 箇所の計 4 箇所になる。
- caller だけを先に入れると `.mise.toml` の宣言と pin が不一致で fail するため、バージョン統一と caller 追加を同一 PR にまとめている。
- ADR 0023 を Superseded にしなかった判断（本文「変更内容」の ADR 節に理由を記載）。


Closes #591
