### PR TITLE
test: [一時/マージ禁止] Toolchain Version Check のネガティブテスト

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -2,7 +2,7 @@ name: Destroy AWS Infrastructure (Reliable)
 
 env:
   PROJECT_NAME: "nestjs-hannibal-3"
-  TERRAFORM_VERSION: "1.14.8"
+  TERRAFORM_VERSION: "1.12.1"
 
 on:
   workflow_dispatch:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-terraform = "1.14.8"
+terraform = "1.12.1"
 node = "24.18.0"
 pre-commit = "4.5.1"
 "terraform-docs" = "0.24.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-terraform = "1.12.1"
+terraform = "1.14.8"
 node = "24.18.0"
 pre-commit = "4.5.1"
 "terraform-docs" = "0.24.0"


### PR DESCRIPTION
**この PR は CI 検証用の一時 PR です。マージ禁止。確認後クローズします。**

## 目的

`Toolchain Version Check` が宣言（`.mise.toml`）と CI pin の不一致を実際に検出して fail するかを、GitHub Actions 上で実測確認する（ネガティブテスト）。

## 変更内容

- `.mise.toml` の terraform 宣言のみを `1.14.8` -> `1.12.1` に変更（意図的な drift）
- workflow 側の pin は変更していない

## 期待結果

`toolchain-version-check / Toolchain Version Check` が **failure** になること。

## 取り扱い

- **マージ禁止**
- 確認完了後にクローズし、ブランチも削除する
- 必須ラベル等の他の CI が落ちるのは想定内