### PR TITLE
docs: 2026-08-10 のツールチェーン統一に伴う docs 反映を整える

### DIFF
--- a/.claude/skills/run-local-map/SKILL.md
+++ b/.claude/skills/run-local-map/SKILL.md
@@ -7,13 +7,18 @@ description: terraform-hannibal のバックエンド（NestJS + GraphQL）と�
 
 バックエンドとフロントエンドをローカルで起動し、`http://localhost:5173/` で地図描画を目視確認するための手順。
 2026-08-10 に WSL 上で実機検証済み。コマンドはそのまま実行できる。
+未検証の箇所は本文中でその都度「未検証」と明記している（前提の Node.js バージョン、後片付けの前景 `Ctrl+C` 経路）。
 
 作業ディレクトリはリポジトリルート（`terraform-hannibal/`）を前提とする。
 
 ## 前提
 
 - Docker が利用できること
-- Node.js が `.mise.toml` の version で入っていること（`mise install`）
+- Node.js 24 系が使えること
+
+Node.js のバージョンについて: 2026-08-10 の検証はシステムの Node **v24.14.1** で実施した。
+`.mise.toml` が宣言する **24.18.0**（`mise install` で入る version）での動作は未検証。
+どちらも Node 24 系であり `engines.node` の `>=24 <25` を満たすため通る見込みだが、実測はしていない。
 
 ## 手順
 
@@ -38,7 +43,16 @@ docker exec hannibal-pg-local pg_isready -U devuser -d hannibal
 
 ### 2. バックエンドを起動する
 
-リポジトリルートで実行する。
+リポジトリルートで実行する。まず依存をインストールする。
+
+```bash
+npm ci
+```
+
+`client/` 側と同様、ルート側も `node_modules` が lock file と乖離していることがあるため省略しない（後述の落とし穴を参照）。
+2026-08-11 に実測して約 17 秒 / 928 packages で完了することを確認済み。
+
+続いて起動する。
 
 ```bash
 DATABASE_URL="postgresql://devuser:devpass@localhost:55432/hannibal?sslmode=disable" \
@@ -140,17 +154,21 @@ git checkout -- src/graphql/graphql.schema.ts
 地図が使う 3 クエリ（`capitalCities` / `hannibalRoute` / `pointRoute`）自体は `src/geojson_data/` の静的データを返すため DB 非依存だが、DB がないとアプリ自体が起動しない。
 「地図を見るだけだから DB は不要」と判断して手順 1 を飛ばさないこと。
 
-### `.env.example` の `VITE_GRAPHQL_ENDPOINT` はそのまま使えない
+### `client/.env.example` の `VITE_GRAPHQL_ENDPOINT` はそのまま使えない
 
-`.env.example` の `VITE_GRAPHQL_ENDPOINT=/graphql` は、CloudFront 配下で同一オリジンに揃う**本番構成向け**の相対パス。
+`client/.env.example` の `VITE_GRAPHQL_ENDPOINT=/graphql` は、CloudFront 配下で同一オリジンに揃う**本番構成向け**の相対パス。
 vite dev サーバには proxy 設定がないため、dev では手順 3 のように**絶対 URL** を指定する必要がある。
+`VITE_GRAPHQL_ENDPOINT` を持つのは `client/.env.example` であり、リポジトリルートの `.env.example` には無い。
 
 ### vite のポートを変えると CORS で弾かれる
 
 `src/app.setup.ts` は `NODE_ENV=development` のとき `http://localhost:5173` と `http://192.168.1.3:5173` のみを許可する。
 vite が別ポート（`5174` など）にフォールバックすると CORS エラーになるため、`5173` が空いていることを確認する。
 
-### 依存更新の検証では `npm ci` を省略しない
+### 依存更新の検証では `npm ci` を省略しない（ルート / `client/` の両方）
+
+このリポジトリは npm workspaces を使わず、ルート（`package-lock.json`）と `client/`（`client/package-lock.json`）が独立した 2 つの npm プロジェクトになっている。
+`npm ci` は片方を実行しても他方には及ばないため、手順 2（ルート）と手順 4（`client/`）でそれぞれ実行する。
 
 `client/node_modules` が lock file と乖離していることがある。
 2026-08-10 の検証時は `client/package-lock.json` が mapbox-gl 3.28.0 なのに `node_modules` には 3.10.0 が残っており、`npm ci` なしでは 3.28.0 の検証になっていなかった。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ PR 本文には `Closes #<issue番号>` / `Fixes #<issue番号>` / `Refs #<issue
 
 ### 実行してよい検証コマンド
 
-ローカルの Terraform バージョンは `.mise.toml`（`1.14.8`）が正本。`mise install` 済みであることを前提とし、CI の pin と一致していることは `Toolchain Version Check` が検査する（ADR 0031）。
+ローカルの Terraform バージョンは `.mise.toml`（`1.14.8`）が正本。`mise install` 済みであることを前提とし、CI の pin と一致していることは `toolchain-version-check / Toolchain Version Check` が検査する（ADR 0031）。check 名が合成名になる理由と一覧は `CONTRIBUTING.md` を参照する。
 
 ```bash
 # フォーマットチェック（差分なしが正常）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,18 +383,41 @@ Issue 本文には専用の運用区分欄を追加せず、Issue 起票前プ�
 
 ### required status checks（マージ必須）
 
-以下の4つが成功しないと `main` へのマージができません。
+以下の7つが成功しないと `main` へのマージができません（2026-08-11 時点。実設定は `gh api repos/:owner/:repo/branches/main/protection/required_status_checks --jq '{strict, contexts}'` で確認できます）。
 
-- `PR Policy Check` — Issueリンク・必須ラベル・ロールバック欄の検査
+- `pr-policy-check / PR Policy Check` — Issueリンク・必須ラベル・ロールバック欄の検査
+- `commitlint / Commitlint` — PR title・PR内コミットメッセージの Conventional Commits 検査
+- `gitleaks / Gitleaks Secret Scan` — git 履歴への secret 混入検査
 - `Backend Lint & Build` — ESLint・NestJS ビルド
 - `Frontend Build` — React ビルド
 - `Terraform Format & Validate` — `terraform fmt` / `terraform validate`
-
-`Commitlint` は PR title・PR内コミットメッセージを検査する CI check です。
-required status check に含める場合は、workflow 追加後に GitHub の branch protection 設定も同期します。
+- `TFLint` — Terraform / AWS provider 向け lint
 
 `Toolchain Version Check` は `.mise.toml` が宣言する Terraform バージョンと CI の pin が一致することを検査する CI check です。
 新しいガードレールのため required status check には含めていません（[ADR 0031](./docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md)）。
+
+このリポジトリでの実際の check run 名は **`toolchain-version-check / Toolchain Version Check`** です。
+required status check へ昇格させる場合は、この合成名を branch protection の context に指定します。
+
+### caller/callee 合成 check 名
+
+`idp-golden-path` の reusable workflow を消費する caller workflow の check 名は、`<caller の job id> / <callee の job 名>` という合成名になります。
+現在 required status check に登録済みのものも、この形式です。
+
+| workflow | check run 名 | required |
+|---|---|---|
+| `pr-policy-check.yml` | `pr-policy-check / PR Policy Check` | 対象 |
+| `pr-commitlint.yml` | `commitlint / Commitlint` | 対象 |
+| `gitleaks-secret-scan.yml` | `gitleaks / Gitleaks Secret Scan` | 対象 |
+| `toolchain-version-check.yml` | `toolchain-version-check / Toolchain Version Check` | 対象外 |
+| `markdown-lint.yml` | `markdown-lint / Markdown Lint` | 対象外 |
+| `codeql.yml` | `analyze / CodeQL Analyze (<language>)` | 対象外 |
+| `dependency-audit.yml` | `root / Dependency Audit` / `client / Dependency Audit` | 対象外 |
+
+caller job にあえて `name:` を付けず job id にフォールバックさせているのは、callee と同名にすると `Commitlint / Commitlint` のように文字列がそのまま重複して可読性を損なうためです（[GitHub Flow Guardrails](./docs/operations/github-flow-guardrails.md)）。
+合成のされ方は caller 側の job id に依存するため、check 名はリポジトリごとに異なり得ます。
+branch protection に登録する前に、実際の名前を `gh pr checks <PR番号>` で確認してください。
+存在しない context を required に指定すると、その check は永久に未充足のままになり PR がマージできなくなります。
 
 ### terraform plan の扱い
 

--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ Terraform root module の README は terraform-docs により pre-commit で更�
 
 ---
 
-**最終更新**: 2026年6月27日 JST
+**最終更新**: 2026年8月11日 JST

--- a/docs/adr/0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md
+++ b/docs/adr/0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md
@@ -127,6 +127,18 @@ pre-commit で root module README を生成できる状態を先に作り、CI r
 
 Terraform のバージョン値自体も ADR 0031 で `1.14.8` に更新されている。本 ADR 本文中の記述は採択当時のものとして残す。
 
+### 追記（2026-08-10）: terraform-docs でも drift が現実化していた（PR #590）
+
+同じ drift は terraform-docs でも起きていた。本 ADR で採択した「CI での terraform-docs 差分チェックは追加せず、pre-commit によるローカル更新に留める」という判断の短所が、そのまま表面化した形である。
+
+`.mise.toml` の `terraform-docs = "0.24.0"` は初回導入（[PR #431](https://github.com/kmryst/terraform-hannibal/pull/431)）から一度も変わっていない（`git log --follow -- .mise.toml` で確認）。にもかかわらず、Terraform root module README を実際に生成していたのは 0.20.0 だった。Terraform と同様に、mise が導入されていなければ `.mise.toml` の宣言に強制力がなく、手元の別経路で入ったバイナリが使われる。
+
+0.24.0 で再生成した結果の差分は、Markdown 表の区切り行の書式のみ（`|------|` → `| ---- |`）で、表の内容（input / output / resource の一覧）に変化はなかった。terraform-docs 側の出力整形が変わったことによるもので、ドキュメントの意味は変わっていない。
+
+[PR #590](https://github.com/kmryst/terraform-hannibal/pull/590) は `terraform/foundation` / `terraform/observability` / `terraform/service` の 3 つの README のみを変更した。`terraform/network` / `terraform/database` / `terraform/cdn` が含まれていないのは漏れではなく、これらは元から 0.24.0 の出力と一致していて差分が出なかったためである。6 root module すべてに対して `terraform-docs markdown table --output-file README.md --output-check` を 0.24.0 で実行し、全て `is up to date` になることを確認した。
+
+この乖離は ADR 0031 が導入した Toolchain Version Check では検出できない。同検査は「`.mise.toml` の宣言」と「workflow の pin」という 2 つの宣言を突き合わせるものだが、terraform-docs は CI で実行しないため比較対象となる pin が存在せず、そもそも乖離していたのは宣言同士ではなく宣言と生成物だからである。機械的に検出するなら、本 ADR が見送った CI gate 化（`terraform-docs --output-check` を PR で実行する）が必要になる。現時点では再導入せず、drift の再発頻度を見て別途判断する。
+
 ## 関連
 
 - [Issue #427](https://github.com/kmryst/terraform-hannibal/issues/427)

--- a/docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md
+++ b/docs/adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md
@@ -98,7 +98,12 @@ version source を完全に一本化でき、drift が原理的に発生しな�
 - `foundation` 層は、ローカル CLI が 1.14.8 になることで **更新経路が回復する**。これが本変更の実質的な効果である
 - 一度 1.14.8 で apply した state は 1.12.1 の CLI で操作できなくなる。ロールバックはこの PR をマージし apply する前に限り無害である
 - 全 6 root module が Terraform 1.14.8 で `fmt -check -recursive` / `init -backend=false` / `validate` を通ることをローカルで実測確認した。`fmt -check` の結果は 1.12.1 と 1.14.8 で同一（どちらも差分なし）、deprecation warning は 0 件、`.terraform.lock.hcl` の変更も発生しなかった
-- 検査対象は Terraform のみである。TFLint は `.mise.toml`（`0.62.1`）と `pr-check.yml`（`v0.62.1`）が一致しているが検査されない。Node.js は `.mise.toml` が `24.18.0`、workflow が major のみの `24` で粒度が異なるため、そもそも一致検査になじまない
+- 検査対象は Terraform のみである。`.mise.toml` が宣言する他の 3 ツールはいずれも検査対象外として残る
+  - TFLint: `.mise.toml`（`0.62.1`）と `pr-check.yml`（`v0.62.1`）が一致しているが検査されない
+  - Node.js: `.mise.toml` が `24.18.0`、workflow が major のみの `24` で粒度が異なるため、そもそも一致検査になじまない
+  - terraform-docs: `.mise.toml`（`0.24.0`）に対応する pin が workflow 側に存在しない。terraform-docs は CI で実行せず pre-commit のローカル実行に留めているため（[ADR 0023](./0023-adopt-mise-for-local-tooling-and-pre-commit-terraform-docs.md)）、比較対象そのものが無い
+- **terraform-docs では、この ADR が扱う drift が既に顕在化していた。** `.mise.toml` の `terraform-docs = "0.24.0"` は初回導入（[PR #431](https://github.com/kmryst/terraform-hannibal/pull/431)）から一度も変わっていないにもかかわらず、Terraform root module README を実際に生成していたのは 0.20.0 であり、宣言と実効値が乖離していた。2026-08-10 に 0.24.0 で再生成して [PR #590](https://github.com/kmryst/terraform-hannibal/pull/590) で是正済みである。本 ADR の検査対象は Terraform のみのため、この種の乖離は今後も CI では検出できない
+- terraform-docs の乖離は Terraform の drift と原因が異なる。Terraform は「宣言と CI pin という 2 つの宣言がずれた」ケースで、両方が宣言なので機械比較できる。terraform-docs は「宣言と、ローカルに実在するバイナリの実効値がずれた」ケースであり、比較相手は他の宣言ではなく生成物である。したがって pin 同士の突き合わせでは検出できず、検出するなら CI で `terraform-docs --output-check` を実行して生成物の差分を見る形になる（本 ADR の scope 外。ADR 0023 が見送った CI gate 化の再検討事項）
 
 ## 再検討条件
 
@@ -107,6 +112,7 @@ version source を完全に一本化でき、drift が原理的に発生しな�
 - **CI が mise を直接使う構成へ移行した場合**（案 D）。ローカル正本と CI pin の二重管理そのものが不要になり、本 ADR の検査も役目を終える
 - **`.mise.toml` 以外のツールチェーン宣言方式へ移行した場合**（`.tool-versions` / devcontainer / Nix など）。検査器のパーサを差し替える必要がある
 - **TFLint / Node.js も検査対象に加えたくなった場合**。reusable workflow 側の拡張として `idp-golden-path` で判断する
+- **terraform-docs の宣言と実効値の乖離を機械的に検出したくなった場合**。これは pin 同士の比較ではなく生成物の差分検査になるため、本 ADR の検査器の拡張ではなく、ADR 0023 が見送った terraform-docs の CI gate 化（`--output-check`）として判断する
 
 ## 関連
 

--- a/docs/operations/github-flow-guardrails.md
+++ b/docs/operations/github-flow-guardrails.md
@@ -14,7 +14,7 @@ Terraform / AWS / SRE 実践としての固有判断はこのリポジトリに�
 
 ## 現時点の技術的な未収束点
 
-2026-07-13 時点では、方針と docs は `idp-golden-path` の型へ寄せていますが、技術実装はまだ完全には収束していません。
+2026-08-11 時点では、方針と docs は `idp-golden-path` の型へ寄せていますが、技術実装はまだ完全には収束していません。
 
 - Commitlint / Sync Labels / PR Policy Check / Gitleaks は `idp-golden-path` の reusable workflow を `@v1` で消費する薄い caller workflow に移行済み（Issue #495 / #498 / #496 / #497）。共通ガードレール4種の移行はすべて完了した。
 - Gitleaks は `pr-check.yml` 内の job から独立した `gitleaks-secret-scan.yml` に切り出した。`.gitleaks.toml`（`client/dist/assets/` 配下の allowlist）は、reusable workflow が config 引数なしで実行しても gitleaks のデフォルト自動検出（カレントディレクトリの `.gitleaks.toml` を読む）により有効に働くことを実測確認した。実行方式は `gitleaks/gitleaks-action` 相当のインストール手順からバイナリ直接インストール（checksum 検証付き）に変わる。

--- a/docs/operations/quality-gates.md
+++ b/docs/operations/quality-gates.md
@@ -11,10 +11,18 @@
 
 ## PR チェック
 
+Job 列は PR に実際に作成される check run 名です。
+`idp-golden-path` の reusable workflow を消費する caller workflow は `<caller の job id> / <callee の job 名>` という合成名になります（[github-flow-guardrails.md](./github-flow-guardrails.md)）。
+required status check に登録する際はこの合成名を使います。実設定は `gh api repos/:owner/:repo/branches/main/protection/required_status_checks --jq '{strict, contexts}'` で確認します。
+
 | Job | Workflow | 主な実行条件 | ツール | 役割 | 扱い |
 |---|---|---|---|---|---|
-| `PR Policy Check` | `.github/workflows/pr-policy-check.yml` | `opened` / `synchronize` / `reopened` / `edited` / `labeled` / `unlabeled` | `gh` / `jq` / shell | Issue link、必須ラベル、厳密運用時の rollback 欄を確認 | required status check 対象 |
-| `Commitlint` | `.github/workflows/pr-commitlint.yml` | `opened` / `synchronize` / `reopened` / `edited` | `commitlint` | PR title と PR 内コミットメッセージを Conventional Commits 形式で確認 | required status check 対象 |
+| `pr-policy-check / PR Policy Check` | `.github/workflows/pr-policy-check.yml`（caller） | `opened` / `synchronize` / `reopened` / `edited` / `labeled` / `unlabeled` | `gh` / `jq` / shell | Issue link、必須ラベル、厳密運用時の rollback 欄を確認 | required status check 対象 |
+| `commitlint / Commitlint` | `.github/workflows/pr-commitlint.yml`（caller） | `opened` / `synchronize` / `reopened` / `edited` | `commitlint` | PR title と PR 内コミットメッセージを Conventional Commits 形式で確認 | required status check 対象 |
+| `toolchain-version-check / Toolchain Version Check` | `.github/workflows/toolchain-version-check.yml`（caller） | `opened` / `synchronize` / `reopened` | shell | `.mise.toml` の Terraform 宣言と workflow の `TERRAFORM_VERSION:` / `terraform_version:` リテラルの一致を確認 | PR で自動実行。検出時は fail。required status check 対象外（[ADR 0031](../adr/0031-unify-terraform-version-to-1-14-8-and-verify-toolchain-consistency-in-ci.md)） |
+| `markdown-lint / Markdown Lint` | `.github/workflows/markdown-lint.yml`（caller） | `pull_request`（既定 types） | `markdownlint-cli2` | Markdown ドキュメントの記法を確認 | PR で自動実行。検出時は fail。required status check 対象外 |
+| `analyze / CodeQL Analyze (<language>)` | `.github/workflows/codeql.yml`（caller） | `pull_request` / `main` への `push` / 週次 `schedule` | CodeQL | `actions` と `javascript-typescript` の SAST。結果は Code scanning alerts に出力 | PR で自動実行。required status check 対象外 |
+| `root / Dependency Audit`、`client / Dependency Audit` | `.github/workflows/dependency-audit.yml`（caller） | `pull_request` / 週次 `schedule` / `workflow_dispatch` | `npm audit` | 依存関係の既知脆弱性を確認。root と `client/` は独立した npm プロジェクトのため 2 job | PR で自動実行。required status check 対象外 |
 | `Backend Lint & Build` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | ESLint / Nest build | backend の lint と build を確認 | required status check 対象 |
 | `Backend Test` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | Jest | backend unit test を確認 | PR で自動実行 |
 | `Frontend Build` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | TypeScript / Vite build | frontend の型チェックと build を確認 | required status check 対象 |
@@ -25,7 +33,9 @@
 | `Terraform Format & Validate` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `terraform fmt` / `terraform validate` | HCL の整形と Terraform 構成の基本整合性を確認 | required status check 対象 |
 | `TFLint` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `tflint` | Terraform / AWS provider 向けの lint。非推奨設定、未使用宣言、provider 固有のミスを検出 | required status check 対象。検出時は fail |
 | `Trivy Config Scan` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `trivy config` | Terraform / Dockerfile などの IaC・設定ミスを検出 | PR で自動実行。review signal として扱い、検出しても fail しない |
-| `Gitleaks Secret Scan` | `.github/workflows/pr-check.yml` | `opened` / `synchronize` / `reopened` | `gitleaks` | Git 履歴に混入した API key / token / password などの secret を検出 | required status check 対象。検出時は fail |
+| `gitleaks / Gitleaks Secret Scan` | `.github/workflows/gitleaks-secret-scan.yml`（caller） | `pull_request`（既定 types） | `gitleaks` | Git 履歴に混入した API key / token / password などの secret を検出 | required status check 対象。検出時は fail |
+
+`Issue Template Check`（`.github/workflows/issue-template-check.yml`）は `issues` イベントで起動する Issue 側のガードレールであり、PR には check run を作成しないためこの表には含めません。
 
 ### 2026-06-27 ShellCheck / Hadolint 初期導入
 
@@ -107,6 +117,8 @@ docker buildx imagetools inspect ghcr.io/hadolint/hadolint:v2.14.0
 required status check の context 名は既存の branch protection と互換にするため、次を維持します。
 
 `PR Policy Check` / `Commitlint` / `Backend Lint & Build` / `Frontend Build` / `Terraform Format & Validate` / `TFLint` / `Gitleaks Secret Scan`
+
+これは #415 時点の名前です。その後 `PR Policy Check` / `Commitlint` / `Gitleaks Secret Scan` は `idp-golden-path` の reusable workflow へ移行し、check 名が合成名（`pr-policy-check / PR Policy Check` など）に変わったため、branch protection の context も合わせて更新済みです。現在の一覧は本節ではなく上の「PR チェック」表を参照してください。
 
 ### 2026-06-21 PR Terraform Plan Artifact 一時停止
 


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）

2026-08-10 にマージした PR #588 / #590 / #592 に対する正本 docs の反映漏れを是正する。
とくに ADR 0031 の検査対象外リストからの terraform-docs 欠落と、CONTRIBUTING.md の check 名単独表記は、放置すると将来の運用判断を誤らせる。

## 変更内容（推奨）

- **ADR 0031**: 検査対象外リストを箇条書きに整理し、TFLint / Node.js と並べて terraform-docs を追加。terraform-docs では drift が既に顕在化して PR #590 で是正済みであること、および Terraform の drift と原因が異なる（宣言同士ではなく宣言と生成物の乖離のため pin 比較では検出できない）ことを明記。再検討条件にも 1 項追加
- **ADR 0023**: 2026-08-10 追記の直後に「terraform-docs でも drift が現実化していた（PR #590）」節を追加。差分が表の区切り行の書式のみだったこと、network / database / cdn が PR #590 に含まれないのは漏れではなく差分が無かったためであることを記録
- **CONTRIBUTING.md**: `toolchain-version-check / Toolchain Version Check` を併記し、caller/callee 合成 check 名の一覧表と、合成のされ方が caller の job id 依存でリポジトリごとに異なる旨を追加。required status checks の一覧を実設定（7 件）に合わせて更新
- **CLAUDE.md**: Toolchain Version Check の参照を合成名に統一
- **docs/operations/quality-gates.md**: PR チェック表に `toolchain-version-check / Toolchain Version Check` / `markdown-lint / Markdown Lint` / `analyze / CodeQL Analyze` / `Dependency Audit`（root / client）を追加。`Gitleaks Secret Scan` の workflow を `gitleaks-secret-scan.yml` に、Job 名を合成名に修正。#415 節の context 名一覧が現在の名前ではない旨の注記を追加
- **.claude/skills/run-local-map/SKILL.md**: 前提の Node.js 記述を実測値（v24.14.1 で検証、24.18.0 は未検証）に修正、`.env.example` → `client/.env.example`、手順 2 にルート側 `npm ci` を追加
- **README.md / github-flow-guardrails.md**: as-of 日付を更新

## 影響範囲（推奨）

- **対象**: docs / ADR / CONTRIBUTING.md / CLAUDE.md / `.claude/skills/`
- **非対象**: `terraform/**`、`.github/workflows/**`、`scripts/**`、アプリケーションコード。CI 設定・branch protection の実設定は一切変更していない

## PRラベル（必須）

- **type**: `type:docs`
- **area**: `area:docs`, `area:ci-cd`
- **risk**: `risk:low`
- **cost**: `cost:none`

## 可観測性/検証 *条件付き*

Doc-only のため運用指標としては No-op（適用外）。記述の裏付けとして次を実測した。

| 確認 | 結果 |
|---|---|
| `git log --follow -- .mise.toml` | `terraform-docs = "0.24.0"` は PR #431 の初回導入から未変更（変更コミットは #431 と #592 の 2 件のみ、後者は terraform 行のみ） |
| `terraform-docs markdown table --output-file README.md --output-check terraform/<module>`（v0.24.0、6 root module） | foundation / network / database / service / cdn / observability すべて `is up to date` |
| `gh pr checks 592` | check 名が `toolchain-version-check / Toolchain Version Check` であることを確認 |
| `gh api repos/:owner/:repo/branches/main/protection/required_status_checks` | contexts 7 件を確認（`pr-policy-check / PR Policy Check`, `commitlint / Commitlint`, `gitleaks / Gitleaks Secret Scan`, `Backend Lint & Build`, `Frontend Build`, `Terraform Format & Validate`, `TFLint`） |
| ルート `npm ci` | 成功。約 17 秒 / 928 packages / 0 vulnerabilities（SKILL.md に追記した手順の実測） |
| `node -v` / mise shim | システム `v24.14.1` / mise `v24.18.0`。2026-08-10 の検証が前者だったことを確認 |
| `npm run lint:md` | 変更した 8 ファイルに指摘なし（既存の `docs/worklogs/**` の指摘は本 PR 以前から存在） |

## ロールバック *条件付き*

軽運用のため必須ではない。問題があれば本 PR を revert する。docs のみの変更であり、revert によって実インフラ・CI 設定・branch protection に影響は生じない。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

pre-commit hooks（Terraform fmt / validate / terraform-docs / secret 検出 / shellcheck / shfmt / hadolint）はコミット時に実行し、対象ファイルなしまたは Passed。

</details>

## メモ（レビューポイント）

判断が必要だった箇所と理由:

1. **PR #590 の記録先を ADR 0023 にした理由**: quality-gates.md の「2026-06-27 mise / terraform-docs 導入」節は導入時点で決めた事項の箇条書きであり、2 か月後に起きた事実を混ぜると「導入時に決めたこと」として読めなくなる。一方 ADR 0023 には既に「短所として挙げた drift が現実化した」という 2026-08-10 追記があり、terraform-docs の件はまったく同じ論点の 2 件目。ADR 0023 自身の決定（CI gate 化を見送り pre-commit に留める）に対する事後評価としても、ADR 側が適切と判断した。
2. **quality-gates 表を全面更新した理由**: この表は PR チェックを棚卸しする唯一の表であり、5 行欠落は表の目的そのものを壊している。追加はすべて行追加で実装への影響がなく、別 Issue に切り出すと「Toolchain Version Check だけ足して他 4 つが欠けたまま」という中途半端な状態が残る。よって本 PR のスコープに含め、別 Issue は起票していない。
3. **`Issue Template Check` を表に入れなかった理由**: `issues` イベントで起動し PR には check run を作成しないため、「PR チェック」表の対象ではない。表の直後に、含めない理由を注記した。
4. **`docs/operations/action-pin-review.md` を更新しなかった理由**: 同ファイルは冒頭に「## 確認日 2026-06-10」と明記された日付つきスナップショットであり、生きた台帳ではない。記載値が現在と異なることは仕様どおりで、追随更新するとスナップショットとしての性格が壊れる。次回の pin レビュー時に確認日ごと更新するのが正しい扱いと判断した。
5. **SKILL.md のルート `npm ci` は実測した**: 未検証の手順を書かないため、実際に実行して成功（約 17 秒 / 928 packages）を確認したうえで手順に追加している。


Closes #597
