### PR TITLE
fix(client): nanoid を advisory 修正版へ更新する

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
<!-- 書き方ガイド: Doc-onlyは可観測性=No-op、ダウンタイム/コスト/リスクは'なし'を選択 -->

## 目的（推奨）

`client / Dependency Audit` が `main` で失敗している（PR #602 の CI で発覚。本 PR とは無関係の既存問題）。
`client/package-lock.json` の `nanoid` に high の advisory（`GHSA-2v37-7h3g-55p8`）が出ているため、修正版へ上げてゲートを解消する。

## 変更内容（推奨）

`client/package-lock.json` の `nanoid` を `3.3.17` → `3.3.18` へ更新（`npm update nanoid` による差分のみ）。

## 影響範囲（推奨）

- **対象**: `client/package-lock.json`（`nanoid` エントリのみ）
- **非対象**: `client/package.json`（`postcss` の要求範囲 `^3.3.16` に `3.3.18` が収まるため無変更）

## PRラベル（必須）

- **type**: ちょうど1つ必須
- **area**: 1つ以上必須、複数可
- **risk**: ちょうど1つ必須
- **cost**: ちょうど1つ必須
- **例**: `type:bug`, `area:frontend`, `risk:low`, `cost:none`

<details>
<summary>影響メモ（必要時のみ）</summary>

**ダウンタイム詳細**（計画ありの場合）: なし
**コスト根拠**（小/中/大の場合）: 依存関係のパッチバージョン更新のみ、コスト影響なし
**リスク根拠**（Medium/Highの場合）: 該当なし（low）

</details>

## 可観測性/検証 *条件付き*

- `client` ディレクトリで `npm audit --audit-level=high` を実行し、修正前（exit 1、`nanoid < 3.3.18` の high advisory を検出）→ 修正後（exit 0、`found 0 vulnerabilities`）を確認した
- `npm ci` で `node_modules/nanoid` が `3.3.18` になることを確認した
- `npm run build`（CI の `Frontend Build` と同じコマンド）が成功することを確認した

## ロールバック *条件付き*

`git revert` で本コミットを取り消せば `nanoid` は `3.3.17` に戻る。`client/package.json` は変更していないため、他の依存関係への影響はない。

## リリース連携（推奨）

- **リリースノート**: 不要

<details>
<summary>テスト結果/検証手順</summary>

```
$ npm audit --audit-level=high   # 修正前
nanoid  <3.3.18
Severity: high
nanoid: custom generators can loop indefinitely when size is zero - https://github.com/advisories/GHSA-2v37-7h3g-55p8
1 high severity vulnerability
exit=1

$ npm update nanoid
added 125 packages, and audited 126 packages in 5s
found 0 vulnerabilities

$ npm audit --audit-level=high   # 修正後
found 0 vulnerabilities
exit=0

$ npm ci && npm run build
exit=0 (両方とも)
```

</details>

## メモ（レビューポイント）

`git diff --stat` は `client/package-lock.json 6 lines changed（+3/-3）` のみ。`nanoid` エントリ以外への差分はない。

Closes #603


Closes #603
